### PR TITLE
fix: package manager install logging

### DIFF
--- a/.changeset/calm-turkeys-pump.md
+++ b/.changeset/calm-turkeys-pump.md
@@ -1,0 +1,5 @@
+---
+'create-wagmi': patch
+---
+
+Fixed issue where package manager install process would not log error

--- a/src/index.ts
+++ b/src/index.ts
@@ -142,26 +142,16 @@ async function run() {
     packageManager === 'npm' ? '--quiet' : '--silent',
   ]
   await oraPromise(
-    new Promise((resolve, reject) => {
-      const child = execa(packageManager, installArgs, {
-        cwd: targetPath,
-        env: {
-          ...process.env,
-          ADBLOCK: '1',
-          DISABLE_OPENCOLLECTIVE: '1',
-          // we set NODE_ENV to development as pnpm skips dev
-          // dependencies when production
-          NODE_ENV: 'development',
-        },
-        stdio: 'ignore',
-      })
-      child.on('close', (code) => {
-        if (code !== 0) {
-          reject({ command: `${packageManager} ${installArgs.join(' ')}` })
-          return
-        }
-        resolve(true)
-      })
+    execa(packageManager, installArgs, {
+      cwd: targetPath,
+      env: {
+        ...process.env,
+        ADBLOCK: '1',
+        DISABLE_OPENCOLLECTIVE: '1',
+        // we set NODE_ENV to development as pnpm skips dev
+        // dependencies when production
+        NODE_ENV: 'development',
+      },
     }),
     {
       text: 'Installing packages. This may take a couple of minutes.',


### PR DESCRIPTION
## Description

This PR refactors how we log the package manager install process, and ensures we are piping out errors correctly.

**Error case**

<img width="878" alt="Screenshot 2022-11-17 at 6 01 25 am" src="https://user-images.githubusercontent.com/7336481/202271326-58d2d2dd-d488-4582-bf93-6682a31fa76b.png">

**Success case**

<img width="617" alt="Screenshot 2022-11-17 at 6 07 38 am" src="https://user-images.githubusercontent.com/7336481/202271334-c07dae25-bbf5-43ba-b0d5-fa226b134c1f.png">

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/create/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: jxom.eth
