### PR TITLE
Update readme - remove unsupported vite templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,7 @@ yarn create wagmi --template next-with-connectkit
 - `next-rainbowkit`: A Next.js wagmi project with RainbowKit included.
 - `next-web3modal`: A Next.js wagmi project with Web3Modal included.
 - `vite-react`: A Vite (React) wagmi project.
-- `vite-react-connectkit`: A Vite (React) wagmi project with ConnectKit included.
-- `vite-react-rainbowkit`: A Vite (React) wagmi project with RainbowKit included.
-- `vite-react-web3modal`: A Vite (React) wagmi project with Web3Modal included.
+- `create-react-app`: A Create React App wagmi project
 
 ## Options
 


### PR DESCRIPTION
## Description

Updated project readme: removed the following templates:
- `vite-react-connectkit`
- `vite-react-rainbowkit`
- `vite-react-web3modal`
and added `create-react-app`. After this update, the readme will be up-to-date with the [https://wagmi.sh/cli/create-wagmi](https://wagmi.sh/cli/create-wagmi).

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/create/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: khazra.eth
