### PR TITLE
chore: update repo link in package.json

### DIFF
--- a/.changeset/five-melons-punch.md
+++ b/.changeset/five-melons-punch.md
@@ -1,0 +1,5 @@
+---
+'create-wagmi': patch
+---
+
+Updated repo link in package.json

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/wagmi-dev/wagmi.git"
+    "url": "https://github.com/wagmi-dev/create-wagmi.git"
   },
   "pnpm": {
     "overrides": {


### PR DESCRIPTION
## Description

Was pointing to wrong repo link before

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/create/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: awkweb.eth
