### PR TITLE
feat: correct usage env variables in vite

### DIFF
--- a/.changeset/tricky-donuts-give.md
+++ b/.changeset/tricky-donuts-give.md
@@ -1,0 +1,5 @@
+---
+'create-wagmi': minor
+---
+
+Fixed import env variables in vite templates

--- a/templates/vite-react/default/src/wagmi.ts
+++ b/templates/vite-react/default/src/wagmi.ts
@@ -7,7 +7,7 @@ import { WalletConnectConnector } from 'wagmi/connectors/walletConnect'
 import { publicProvider } from 'wagmi/providers/public'
 
 const { chains, provider, webSocketProvider } = configureChains(
-  [mainnet, ...(process.env.NODE_ENV === 'development' ? [goerli] : [])],
+  [mainnet, ...(import.meta.env.NODE_ENV === 'development' ? [goerli] : [])],
   [publicProvider()],
 )
 

--- a/templates/vite-react/rainbowkit/src/wagmi.ts
+++ b/templates/vite-react/rainbowkit/src/wagmi.ts
@@ -4,7 +4,7 @@ import { goerli, mainnet } from 'wagmi/chains'
 import { publicProvider } from 'wagmi/providers/public'
 
 const { chains, provider, webSocketProvider } = configureChains(
-  [mainnet, ...(process.env.NODE_ENV === 'development' ? [goerli] : [])],
+  [mainnet, ...(import.meta.env.NODE_ENV === 'development' ? [goerli] : [])],
   [publicProvider()],
 )
 

--- a/templates/vite-react/web3modal/src/wagmi.ts
+++ b/templates/vite-react/web3modal/src/wagmi.ts
@@ -5,7 +5,7 @@ import { goerli, mainnet } from 'wagmi/chains'
 export const walletConnectProjectId = 'ba7804e457fbb5f1375cbdc14e679617'
 
 const { chains, provider, webSocketProvider } = configureChains(
-  [mainnet, ...(process.env.NODE_ENV === 'development' ? [goerli] : [])],
+  [mainnet, ...(import.meta.env.NODE_ENV === 'development' ? [goerli] : [])],
   [walletConnectProvider({ projectId: walletConnectProjectId })],
 )
 


### PR DESCRIPTION
## Description

In vite, `import.meta.env` is used to [get env values](https://vitejs.dev/guide/env-and-mode.html#env-variables), the current templates used `process` for this, which is not valid


## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/create/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
- insuline.eth