### PR TITLE
chore: update wagmi

### DIFF
--- a/.changeset/late-ants-judge.md
+++ b/.changeset/late-ants-judge.md
@@ -1,0 +1,5 @@
+---
+'create-wagmi': patch
+---
+
+Updated wagmi to 0.12.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,14 +86,14 @@ importers:
       react: ^18.2.0
       react-dom: ^18.2.0
       typescript: ^4.9.4
-      wagmi: ~0.11.0
+      wagmi: ~0.12.0
     dependencies:
-      '@wagmi/cli': 0.1.5_sc5zqy2ifbojqlygl4abm5h7ha
+      '@wagmi/cli': 0.1.11_5eydqnj6xumuwfaftfakghoei4
       ethers: 5.7.2
       next: 13.0.5_biqbaboplfbrettd7655fr4n2y
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      wagmi: 0.11.0_q3rmnbwwunsufccbu3lnf7uwce
+      wagmi: 0.12.1_q3rmnbwwunsufccbu3lnf7uwce
     devDependencies:
       '@types/node': 17.0.45
       '@types/react': 18.0.25
@@ -115,14 +115,14 @@ importers:
       react: ^18.2.0
       react-dom: ^18.2.0
       typescript: ^4.9.4
-      wagmi: ~0.11.0
+      wagmi: ~0.12.0
     dependencies:
-      '@wagmi/cli': 0.1.5_sc5zqy2ifbojqlygl4abm5h7ha
+      '@wagmi/cli': 0.1.11_5eydqnj6xumuwfaftfakghoei4
       ethers: 5.7.2
       next: 13.0.5_biqbaboplfbrettd7655fr4n2y
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      wagmi: 0.11.0_q3rmnbwwunsufccbu3lnf7uwce
+      wagmi: 0.12.1_q3rmnbwwunsufccbu3lnf7uwce
     devDependencies:
       '@types/node': 17.0.45
       '@types/react': 18.0.25
@@ -144,14 +144,14 @@ importers:
       react: ^18.2.0
       react-dom: ^18.2.0
       typescript: ^4.9.4
-      wagmi: ~0.11.0
+      wagmi: ~0.12.0
     dependencies:
-      '@wagmi/cli': 0.1.5_sc5zqy2ifbojqlygl4abm5h7ha
+      '@wagmi/cli': 0.1.11_5eydqnj6xumuwfaftfakghoei4
       ethers: 5.7.2
       next: 13.0.5_biqbaboplfbrettd7655fr4n2y
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      wagmi: 0.11.0_q3rmnbwwunsufccbu3lnf7uwce
+      wagmi: 0.12.1_q3rmnbwwunsufccbu3lnf7uwce
     devDependencies:
       '@types/node': 17.0.45
       '@types/react': 18.0.25
@@ -173,14 +173,14 @@ importers:
       react: ^18.2.0
       react-dom: ^18.2.0
       typescript: ^4.9.4
-      wagmi: ~0.11.0
+      wagmi: ~0.12.0
     dependencies:
-      '@wagmi/cli': 0.1.5_sc5zqy2ifbojqlygl4abm5h7ha
+      '@wagmi/cli': 0.1.11_5eydqnj6xumuwfaftfakghoei4
       ethers: 5.7.2
       next: 13.0.5_biqbaboplfbrettd7655fr4n2y
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      wagmi: 0.11.0_q3rmnbwwunsufccbu3lnf7uwce
+      wagmi: 0.12.1_q3rmnbwwunsufccbu3lnf7uwce
     devDependencies:
       '@types/node': 17.0.45
       '@types/react': 18.0.25
@@ -204,12 +204,12 @@ importers:
       typescript: ^4.9.4
       wagmi: ~0.11.0
     dependencies:
-      connectkit: 1.1.1_li4huv3xlw7e2ejfg4w23au2re
+      connectkit: 1.1.1_fz36zj7lqr4mpddduwobg5rhxi
       ethers: 5.7.2
       next: 13.0.5_biqbaboplfbrettd7655fr4n2y
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      wagmi: 0.11.0_q3rmnbwwunsufccbu3lnf7uwce
+      wagmi: 0.11.7_q3rmnbwwunsufccbu3lnf7uwce
     devDependencies:
       '@types/node': 17.0.45
       '@types/react': 18.0.25
@@ -230,13 +230,13 @@ importers:
       react: ^18.2.0
       react-dom: ^18.2.0
       typescript: ^4.9.4
-      wagmi: ~0.11.0
+      wagmi: ~0.12.0
     dependencies:
       ethers: 5.7.2
       next: 13.0.5_biqbaboplfbrettd7655fr4n2y
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      wagmi: 0.11.0_q3rmnbwwunsufccbu3lnf7uwce
+      wagmi: 0.12.1_q3rmnbwwunsufccbu3lnf7uwce
     devDependencies:
       '@types/node': 17.0.45
       '@types/react': 18.0.25
@@ -247,7 +247,7 @@ importers:
 
   templates/next/rainbowkit:
     specifiers:
-      '@rainbow-me/rainbowkit': ^0.8.1
+      '@rainbow-me/rainbowkit': ~0.12.1
       '@types/node': ^17.0.31
       '@types/react': ^18.0.9
       '@types/react-dom': ^18.0.3
@@ -258,14 +258,14 @@ importers:
       react: ^18.2.0
       react-dom: ^18.2.0
       typescript: ^4.9.4
-      wagmi: ~0.11.0
+      wagmi: ~0.12.0
     dependencies:
-      '@rainbow-me/rainbowkit': 0.8.1_2ycvyfzrdkotg2xh2a6qkhvz2q
+      '@rainbow-me/rainbowkit': 0.12.1_doaeszmvs3nzseycvvytlpjuqe
       ethers: 5.7.2
       next: 13.0.5_biqbaboplfbrettd7655fr4n2y
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      wagmi: 0.11.0_q3rmnbwwunsufccbu3lnf7uwce
+      wagmi: 0.12.1_q3rmnbwwunsufccbu3lnf7uwce
     devDependencies:
       '@types/node': 17.0.45
       '@types/react': 18.0.25
@@ -279,8 +279,8 @@ importers:
       '@types/node': ^17.0.31
       '@types/react': ^18.0.9
       '@types/react-dom': ^18.0.3
-      '@web3modal/ethereum': 2.0.0-beta.6
-      '@web3modal/react': 2.0.0-beta.6
+      '@web3modal/ethereum': 2.2.0
+      '@web3modal/react': 2.2.0
       eslint: ^8.15.0
       eslint-config-next: ^12.1.6
       ethers: ^5.7.2
@@ -288,15 +288,15 @@ importers:
       react: ^18.2.0
       react-dom: ^18.2.0
       typescript: ^4.9.4
-      wagmi: ~0.11.0
+      wagmi: ~0.12.0
     dependencies:
-      '@web3modal/ethereum': 2.0.0-beta.6_ethers@5.7.2
-      '@web3modal/react': 2.0.0-beta.6_biqbaboplfbrettd7655fr4n2y
+      '@web3modal/ethereum': 2.2.0_ethers@5.7.2
+      '@web3modal/react': 2.2.0_biqbaboplfbrettd7655fr4n2y
       ethers: 5.7.2
       next: 13.0.5_biqbaboplfbrettd7655fr4n2y
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      wagmi: 0.11.0_q3rmnbwwunsufccbu3lnf7uwce
+      wagmi: 0.12.1_q3rmnbwwunsufccbu3lnf7uwce
     devDependencies:
       '@types/node': 17.0.45
       '@types/react': 18.0.25
@@ -319,16 +319,16 @@ importers:
       typescript: ^4.9.4
       util: ^0.12.4
       vite: ^3.1.8
-      wagmi: ~0.11.0
+      wagmi: ~0.12.0
     dependencies:
-      '@wagmi/cli': 0.1.5_sc5zqy2ifbojqlygl4abm5h7ha
+      '@wagmi/cli': 0.1.11_5eydqnj6xumuwfaftfakghoei4
       buffer: 6.0.3
       ethers: 5.7.2
       process: 0.11.10
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       util: 0.12.5
-      wagmi: 0.11.0_5fkdkfy2bkgsnhvxgn477z7iae
+      wagmi: 0.12.1_5fkdkfy2bkgsnhvxgn477z7iae
     devDependencies:
       '@types/react': 18.0.25
       '@types/react-dom': 18.0.9
@@ -350,16 +350,16 @@ importers:
       typescript: ^4.9.4
       util: ^0.12.4
       vite: ^3.1.8
-      wagmi: ~0.11.0
+      wagmi: ~0.12.0
     dependencies:
-      '@wagmi/cli': 0.1.5_sc5zqy2ifbojqlygl4abm5h7ha
+      '@wagmi/cli': 0.1.11_5eydqnj6xumuwfaftfakghoei4
       buffer: 6.0.3
       ethers: 5.7.2
       process: 0.11.10
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       util: 0.12.5
-      wagmi: 0.11.0_5fkdkfy2bkgsnhvxgn477z7iae
+      wagmi: 0.12.1_5fkdkfy2bkgsnhvxgn477z7iae
     devDependencies:
       '@types/react': 18.0.25
       '@types/react-dom': 18.0.9
@@ -381,16 +381,16 @@ importers:
       typescript: ^4.9.4
       util: ^0.12.4
       vite: ^3.1.8
-      wagmi: ~0.11.0
+      wagmi: ~0.12.0
     dependencies:
-      '@wagmi/cli': 0.1.5_sc5zqy2ifbojqlygl4abm5h7ha
+      '@wagmi/cli': 0.1.11_5eydqnj6xumuwfaftfakghoei4
       buffer: 6.0.3
       ethers: 5.7.2
       process: 0.11.10
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       util: 0.12.5
-      wagmi: 0.11.0_5fkdkfy2bkgsnhvxgn477z7iae
+      wagmi: 0.12.1_5fkdkfy2bkgsnhvxgn477z7iae
     devDependencies:
       '@types/react': 18.0.25
       '@types/react-dom': 18.0.9
@@ -412,16 +412,16 @@ importers:
       typescript: ^4.9.4
       util: ^0.12.4
       vite: ^3.1.8
-      wagmi: ~0.11.0
+      wagmi: ~0.12.0
     dependencies:
-      '@wagmi/cli': 0.1.5_sc5zqy2ifbojqlygl4abm5h7ha
+      '@wagmi/cli': 0.1.11_5eydqnj6xumuwfaftfakghoei4
       buffer: 6.0.3
       ethers: 5.7.2
       process: 0.11.10
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       util: 0.12.5
-      wagmi: 0.11.0_5fkdkfy2bkgsnhvxgn477z7iae
+      wagmi: 0.12.1_5fkdkfy2bkgsnhvxgn477z7iae
     devDependencies:
       '@types/react': 18.0.25
       '@types/react-dom': 18.0.9
@@ -446,13 +446,13 @@ importers:
       wagmi: ~0.11.0
     dependencies:
       buffer: 6.0.3
-      connectkit: 1.1.1_li4huv3xlw7e2ejfg4w23au2re
+      connectkit: 1.1.1_fz36zj7lqr4mpddduwobg5rhxi
       ethers: 5.7.2
       process: 0.11.10
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       util: 0.12.5
-      wagmi: 0.11.0_5fkdkfy2bkgsnhvxgn477z7iae
+      wagmi: 0.11.7_5fkdkfy2bkgsnhvxgn477z7iae
     devDependencies:
       '@types/react': 18.0.25
       '@types/react-dom': 18.0.9
@@ -473,7 +473,7 @@ importers:
       typescript: ^4.9.4
       util: ^0.12.4
       vite: ^3.1.8
-      wagmi: ~0.11.0
+      wagmi: ~0.12.0
     dependencies:
       buffer: 6.0.3
       ethers: 5.7.2
@@ -481,7 +481,7 @@ importers:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       util: 0.12.5
-      wagmi: 0.11.0_5fkdkfy2bkgsnhvxgn477z7iae
+      wagmi: 0.12.1_5fkdkfy2bkgsnhvxgn477z7iae
     devDependencies:
       '@types/react': 18.0.25
       '@types/react-dom': 18.0.9
@@ -491,7 +491,7 @@ importers:
 
   templates/vite-react/rainbowkit:
     specifiers:
-      '@rainbow-me/rainbowkit': ^0.8.1
+      '@rainbow-me/rainbowkit': ~0.12.1
       '@types/react': ^18.0.9
       '@types/react-dom': ^18.0.3
       '@vitejs/plugin-react': ^2.1.0
@@ -503,16 +503,16 @@ importers:
       typescript: ^4.9.4
       util: ^0.12.4
       vite: ^3.1.8
-      wagmi: ~0.11.0
+      wagmi: ~0.12.0
     dependencies:
-      '@rainbow-me/rainbowkit': 0.8.1_2ycvyfzrdkotg2xh2a6qkhvz2q
+      '@rainbow-me/rainbowkit': 0.12.1_doaeszmvs3nzseycvvytlpjuqe
       buffer: 6.0.3
       ethers: 5.7.2
       process: 0.11.10
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       util: 0.12.5
-      wagmi: 0.11.0_5fkdkfy2bkgsnhvxgn477z7iae
+      wagmi: 0.12.1_5fkdkfy2bkgsnhvxgn477z7iae
     devDependencies:
       '@types/react': 18.0.25
       '@types/react-dom': 18.0.9
@@ -525,8 +525,8 @@ importers:
       '@types/react': ^18.0.9
       '@types/react-dom': ^18.0.3
       '@vitejs/plugin-react': ^2.1.0
-      '@web3modal/ethereum': 2.0.0-beta.6
-      '@web3modal/react': 2.0.0-beta.6
+      '@web3modal/ethereum': 2.2.0
+      '@web3modal/react': 2.2.0
       buffer: ^6.0.3
       ethers: ^5.7.2
       process: ^0.11.10
@@ -535,17 +535,17 @@ importers:
       typescript: ^4.9.4
       util: ^0.12.4
       vite: ^3.1.8
-      wagmi: ~0.11.0
+      wagmi: ~0.12.0
     dependencies:
-      '@web3modal/ethereum': 2.0.0-beta.6_ethers@5.7.2
-      '@web3modal/react': 2.0.0-beta.6_vrbfpf7l3dmha57kzmbjd4uuiq
+      '@web3modal/ethereum': 2.2.0_ethers@5.7.2
+      '@web3modal/react': 2.2.0_biqbaboplfbrettd7655fr4n2y
       buffer: 6.0.3
       ethers: 5.7.2
       process: 0.11.10
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       util: 0.12.5
-      wagmi: 0.11.0_5fkdkfy2bkgsnhvxgn477z7iae
+      wagmi: 0.12.1_5fkdkfy2bkgsnhvxgn477z7iae
     devDependencies:
       '@types/react': 18.0.25
       '@types/react-dom': 18.0.9
@@ -1160,6 +1160,7 @@ packages:
     cpu: [arm]
     os: [android]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/android-arm/0.15.13:
@@ -1177,6 +1178,7 @@ packages:
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-loong64/0.15.13:
@@ -1892,14 +1894,14 @@ packages:
     resolution: {integrity: sha512-HaW78NszGzRZd9SeoI3JD11JqY+lubnaOx7Pewj5pfjqWXOEATpeKIFb9Z4t2WBUK2iryiXX3lzWwmYWgUL0Ug==}
     dev: false
 
-  /@rainbow-me/rainbowkit/0.8.1_2ycvyfzrdkotg2xh2a6qkhvz2q:
-    resolution: {integrity: sha512-A8BjihvgCY/xjQWOpqgOce+uO4mmIV4Qlo3XMF87kk5WNmyLLaPx2oYTJQz1uOinWE77h4G0HozJr5wnrermgw==}
+  /@rainbow-me/rainbowkit/0.12.1_doaeszmvs3nzseycvvytlpjuqe:
+    resolution: {integrity: sha512-zyKKYWBHRs+QUtxi85Lg6eOysy61nVSzDtSh5VRQ45X5j7AsoxGJE3Ddn7GwZvm0Jxt4XIIt79iDQdvkhTbb1Q==}
     engines: {node: '>=12.4'}
     peerDependencies:
       ethers: '>=5.5.1'
       react: '>=17'
       react-dom: '>=17'
-      wagmi: 0.9.x
+      wagmi: 0.12.x
     dependencies:
       '@vanilla-extract/css': 1.9.1
       '@vanilla-extract/dynamic': 2.0.2
@@ -1910,7 +1912,7 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       react-remove-scroll: 2.5.4_fan5qbzahqtxlm5dzefqlqx5ia
-      wagmi: 0.11.0_q3rmnbwwunsufccbu3lnf7uwce
+      wagmi: 0.12.1_q3rmnbwwunsufccbu3lnf7uwce
     transitivePeerDependencies:
       - '@types/react'
     dev: false
@@ -1918,6 +1920,47 @@ packages:
   /@rushstack/eslint-patch/1.2.0:
     resolution: {integrity: sha512-sXo/qW2/pAcmT43VoRKOJbDOfV3cYpq3szSVfIThQXNt+E4DfKj361vaAt3c88U5tPUxzEswam7GW48PJqtKAg==}
     dev: true
+
+  /@safe-global/safe-apps-provider/0.15.2:
+    resolution: {integrity: sha512-BaoGAuY7h6jLBL7P+M6b7hd+1QfTv8uMyNF3udhiNUwA0XwfzH2ePQB13IEV3Mn7wdcIMEEUDS5kHbtAsj60qQ==}
+    dependencies:
+      '@safe-global/safe-apps-sdk': 7.9.0
+      events: 3.3.0
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - utf-8-validate
+    dev: false
+
+  /@safe-global/safe-apps-sdk/7.10.0:
+    resolution: {integrity: sha512-is0QAHVoGkP06YfOPcp4X3/YUEA3wRdgFUyKZ4rT47uOEnzxA9Sm8BFJrIZqZOjjqC+aJXRMF0cE2qucS953rg==}
+    dependencies:
+      '@safe-global/safe-gateway-typescript-sdk': 3.7.0
+      ethers: 5.7.2
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - utf-8-validate
+    dev: false
+
+  /@safe-global/safe-apps-sdk/7.9.0:
+    resolution: {integrity: sha512-S2EI+JL8ocSgE3uGNaDZCzKmwfhtxXZFDUP76vN0FeaY35itFMyi8F0Vhxu0XnZm3yLzJE3tp5px6GhuQFLU6w==}
+    dependencies:
+      '@safe-global/safe-gateway-typescript-sdk': 3.7.0
+      ethers: 5.7.2
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - utf-8-validate
+    dev: false
+
+  /@safe-global/safe-gateway-typescript-sdk/3.7.0:
+    resolution: {integrity: sha512-3BvlUgp0oZ1Zkn7nG3wY1jvCEE4t530BjKcaa3r0qsf0whf/ez/0gmQwk7DTOGmVmvOfjj6HHikxnrUCCX+/3Q==}
+    dependencies:
+      cross-fetch: 3.1.5
+    transitivePeerDependencies:
+      - encoding
+    dev: false
 
   /@solana/buffer-layout/4.0.0:
     resolution: {integrity: sha512-lR0EMP2HC3+Mxwd4YcnZb0smnaDw7Bl2IQWZiTevRH5ZZBZn6VRWn3/92E3qdU4SSImJkA6IDHawOHAnx/qUvQ==}
@@ -2444,8 +2487,8 @@ packages:
       - supports-color
     dev: true
 
-  /@wagmi/chains/0.2.0_typescript@4.9.4:
-    resolution: {integrity: sha512-ysiFMurLaBeFE+GtHUY6GZboMhp8rrEorFBG5PpPMoiwkby70zvFAnj97rH+gfaEqHBFrft0cljM2qPI50aUpw==}
+  /@wagmi/chains/0.2.11_typescript@4.9.4:
+    resolution: {integrity: sha512-aMrI1zKKXdeAaiTxBiv+3Zfgd3IajCDpxBtPPvpjXuWVRe4ikwzbyZ1HARKj3V1+wNMPng8EJiWpN966PcvROg==}
     peerDependencies:
       typescript: '>=4.9.4'
     peerDependenciesMeta:
@@ -2455,8 +2498,8 @@ packages:
       typescript: 4.9.4
     dev: false
 
-  /@wagmi/chains/0.2.6_typescript@4.9.4:
-    resolution: {integrity: sha512-YRvWZ6G5X25BgLB8jCAz7Je3yUh+CvmXujrWnL/1lbXslheEq1Ssf77zRfdQo+zfD4bwL/qHEUNREf8r6usKsA==}
+  /@wagmi/chains/0.2.9_typescript@4.9.4:
+    resolution: {integrity: sha512-z0Nv7Cto+t/47NtC8td7khMSWX0zKVCnm8gkgrRs9PHvN+4W7XZfUVQYfhIfkbelT/ONN9V1OA+ho122gmRr3Q==}
     peerDependencies:
       typescript: '>=4.9.4'
     peerDependenciesMeta:
@@ -2466,8 +2509,8 @@ packages:
       typescript: 4.9.4
     dev: false
 
-  /@wagmi/cli/0.1.5_sc5zqy2ifbojqlygl4abm5h7ha:
-    resolution: {integrity: sha512-HPkpPMBcRQUH23P9WpfXrQtBs+biaVuHSqnc5gq+8owNV/V0nMsMHtOQOLRpbjVbwim2q8ZEB7a9ep9sEzzlQg==}
+  /@wagmi/cli/0.1.11_5eydqnj6xumuwfaftfakghoei4:
+    resolution: {integrity: sha512-JW4WWLgTwXWwRqU+hrWiRDXFNCV18WI5vbMa2KZgtI+jqBlPJYivHUpmwejnOrXSlfbow9wAFuuCA00foxd3RQ==}
     engines: {node: '>=14'}
     hasBin: true
     peerDependencies:
@@ -2483,7 +2526,7 @@ packages:
         optional: true
     dependencies:
       '@ethersproject/address': 5.7.0
-      '@wagmi/chains': 0.2.6_typescript@4.9.4
+      '@wagmi/chains': 0.2.9_typescript@4.9.4
       abitype: 0.3.0_4umapwpw55xijlh2mknjgcn4rq
       abort-controller: 3.0.0
       bundle-require: 3.1.2_esbuild@0.15.13
@@ -2505,15 +2548,15 @@ packages:
       picocolors: 1.0.0
       prettier: 2.8.3
       typescript: 4.9.4
-      wagmi: 0.11.0_q3rmnbwwunsufccbu3lnf7uwce
+      wagmi: 0.12.1_q3rmnbwwunsufccbu3lnf7uwce
       zod: 3.20.2
     dev: false
 
-  /@wagmi/connectors/0.2.0_amq75oizypirqzlqoefqx3xtei:
-    resolution: {integrity: sha512-lqPS/Ck8QUSxaFjvo7gqnXLTEDqCDmk36lhgoP5b0CtEjeykuI5yVEHpF9rJXn9VmPwTKNfdeYZUwDgJrjI11w==}
+  /@wagmi/connectors/0.2.7_q3cmzdgbiw5ulsmbm3iicqs7yy:
+    resolution: {integrity: sha512-9l5XBlaO7AGukvIbgLj3L1VMbRvHmwQTu36t0mQRE90LHzqP45/BK9BtrpUI8DjdmIMwQ+omMqSqBuhawT5Zwg==}
     peerDependencies:
       '@wagmi/core': '>=0.9.x'
-      ethers: '>=5.5.1'
+      ethers: '>=5.5.1 <6'
       typescript: '>=4.9.4'
     peerDependenciesMeta:
       '@wagmi/core':
@@ -2523,10 +2566,12 @@ packages:
     dependencies:
       '@coinbase/wallet-sdk': 3.6.0
       '@ledgerhq/connect-kit-loader': 1.0.2
-      '@wagmi/core': 0.9.0_2zmba3zh2lo2ye5dzgeckiacfa
+      '@safe-global/safe-apps-provider': 0.15.2
+      '@safe-global/safe-apps-sdk': 7.10.0
+      '@wagmi/core': 0.9.7_2zmba3zh2lo2ye5dzgeckiacfa
       '@walletconnect/ethereum-provider': 1.8.0
-      '@walletconnect/universal-provider': 2.3.0_typescript@4.9.4
-      '@web3modal/standalone': 2.0.0_react@18.2.0
+      '@walletconnect/universal-provider': 2.3.3_typescript@4.9.4
+      '@web3modal/standalone': 2.2.0_react@18.2.0
       abitype: 0.3.0_typescript@4.9.4
       ethers: 5.7.2
       eventemitter3: 4.0.7
@@ -2548,11 +2593,11 @@ packages:
       - zod
     dev: false
 
-  /@wagmi/connectors/0.2.0_hfstv6plmtvxfkmvtsxvciubrq:
-    resolution: {integrity: sha512-lqPS/Ck8QUSxaFjvo7gqnXLTEDqCDmk36lhgoP5b0CtEjeykuI5yVEHpF9rJXn9VmPwTKNfdeYZUwDgJrjI11w==}
+  /@wagmi/connectors/0.2.7_ztwhwxvpdf6qmgtw3b63ds6fju:
+    resolution: {integrity: sha512-9l5XBlaO7AGukvIbgLj3L1VMbRvHmwQTu36t0mQRE90LHzqP45/BK9BtrpUI8DjdmIMwQ+omMqSqBuhawT5Zwg==}
     peerDependencies:
       '@wagmi/core': '>=0.9.x'
-      ethers: '>=5.5.1'
+      ethers: '>=5.5.1 <6'
       typescript: '>=4.9.4'
     peerDependenciesMeta:
       '@wagmi/core':
@@ -2562,10 +2607,12 @@ packages:
     dependencies:
       '@coinbase/wallet-sdk': 3.6.0
       '@ledgerhq/connect-kit-loader': 1.0.2
-      '@wagmi/core': 0.9.0_fz5ualg3bc2nr2e6kzfsjxcmya
+      '@safe-global/safe-apps-provider': 0.15.2
+      '@safe-global/safe-apps-sdk': 7.10.0
+      '@wagmi/core': 0.9.7_fz5ualg3bc2nr2e6kzfsjxcmya
       '@walletconnect/ethereum-provider': 1.8.0
-      '@walletconnect/universal-provider': 2.3.0_zpb5kzpnyozdjq4cwaojlul57u
-      '@web3modal/standalone': 2.0.0_react@18.2.0
+      '@walletconnect/universal-provider': 2.3.3_zpb5kzpnyozdjq4cwaojlul57u
+      '@web3modal/standalone': 2.2.0_react@18.2.0
       abitype: 0.3.0_typescript@4.9.4
       ethers: 5.7.2
       eventemitter3: 4.0.7
@@ -2587,17 +2634,97 @@ packages:
       - zod
     dev: false
 
-  /@wagmi/core/0.9.0_2zmba3zh2lo2ye5dzgeckiacfa:
-    resolution: {integrity: sha512-FHa6+11kIaPAFK9MBCiLmJ6mr0uMhGAuRXj2R9ghB/Krcs/Hkr1v2oOumVOlca31I+sx/ZhAkKusLUuDI++LvA==}
+  /@wagmi/connectors/0.3.2_a57jxkfobrnr6ydnpj6ud2g3em:
+    resolution: {integrity: sha512-VZ/lmzR/+Zw4xbQvgXscXvifoNJZbMB4E4rQMUvrlCtHMdK3kxb9BC2KMiPTgfsZmEldz72CMmPbrM8C8X1JCA==}
     peerDependencies:
-      ethers: '>=5.5.1'
+      '@wagmi/core': '>=0.9.x'
+      ethers: '>=5.5.1 <6'
+      typescript: '>=4.9.4'
+    peerDependenciesMeta:
+      '@wagmi/core':
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      '@coinbase/wallet-sdk': 3.6.0
+      '@ledgerhq/connect-kit-loader': 1.0.2
+      '@safe-global/safe-apps-provider': 0.15.2
+      '@safe-global/safe-apps-sdk': 7.10.0
+      '@wagmi/core': 0.10.1_2zmba3zh2lo2ye5dzgeckiacfa
+      '@walletconnect/ethereum-provider': 2.4.9_o77wnou4wwnegu5woljtklrzru
+      '@walletconnect/legacy-provider': 2.0.0
+      abitype: 0.3.0_typescript@4.9.4
+      ethers: 5.7.2
+      eventemitter3: 4.0.7
+      typescript: 4.9.4
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@react-native-async-storage/async-storage'
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+      - bufferutil
+      - debug
+      - encoding
+      - lokijs
+      - react
+      - react-native
+      - supports-color
+      - utf-8-validate
+      - zod
+    dev: false
+
+  /@wagmi/connectors/0.3.2_fpaddhxo5uppwziiwxtk5f5rmm:
+    resolution: {integrity: sha512-VZ/lmzR/+Zw4xbQvgXscXvifoNJZbMB4E4rQMUvrlCtHMdK3kxb9BC2KMiPTgfsZmEldz72CMmPbrM8C8X1JCA==}
+    peerDependencies:
+      '@wagmi/core': '>=0.9.x'
+      ethers: '>=5.5.1 <6'
+      typescript: '>=4.9.4'
+    peerDependenciesMeta:
+      '@wagmi/core':
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      '@coinbase/wallet-sdk': 3.6.0
+      '@ledgerhq/connect-kit-loader': 1.0.2
+      '@safe-global/safe-apps-provider': 0.15.2
+      '@safe-global/safe-apps-sdk': 7.10.0
+      '@wagmi/core': 0.10.1_fz5ualg3bc2nr2e6kzfsjxcmya
+      '@walletconnect/ethereum-provider': 2.4.9_ccd6e3ud4g73fwcdmw2hfpovvi
+      '@walletconnect/legacy-provider': 2.0.0
+      abitype: 0.3.0_typescript@4.9.4
+      ethers: 5.7.2
+      eventemitter3: 4.0.7
+      typescript: 4.9.4
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@react-native-async-storage/async-storage'
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+      - bufferutil
+      - debug
+      - encoding
+      - lokijs
+      - react
+      - react-native
+      - supports-color
+      - utf-8-validate
+      - zod
+    dev: false
+
+  /@wagmi/core/0.10.1_2zmba3zh2lo2ye5dzgeckiacfa:
+    resolution: {integrity: sha512-UmcX4JNBRl20rg8ybPLOA5SEzKdyqEDd0TXqTfowil1T+IMjsZJhoJ/SWdTPkBXbAQyo8GlQ+Yr0lZ3/CKC1Nw==}
+    peerDependencies:
+      ethers: '>=5.5.1 <6'
       typescript: '>=4.9.4'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@wagmi/chains': 0.2.0_typescript@4.9.4
-      '@wagmi/connectors': 0.2.0_amq75oizypirqzlqoefqx3xtei
+      '@wagmi/chains': 0.2.11_typescript@4.9.4
+      '@wagmi/connectors': 0.3.2_a57jxkfobrnr6ydnpj6ud2g3em
       abitype: 0.3.0_typescript@4.9.4
       ethers: 5.7.2
       eventemitter3: 4.0.7
@@ -2621,17 +2748,85 @@ packages:
       - zod
     dev: false
 
-  /@wagmi/core/0.9.0_fz5ualg3bc2nr2e6kzfsjxcmya:
-    resolution: {integrity: sha512-FHa6+11kIaPAFK9MBCiLmJ6mr0uMhGAuRXj2R9ghB/Krcs/Hkr1v2oOumVOlca31I+sx/ZhAkKusLUuDI++LvA==}
+  /@wagmi/core/0.10.1_fz5ualg3bc2nr2e6kzfsjxcmya:
+    resolution: {integrity: sha512-UmcX4JNBRl20rg8ybPLOA5SEzKdyqEDd0TXqTfowil1T+IMjsZJhoJ/SWdTPkBXbAQyo8GlQ+Yr0lZ3/CKC1Nw==}
     peerDependencies:
-      ethers: '>=5.5.1'
+      ethers: '>=5.5.1 <6'
       typescript: '>=4.9.4'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@wagmi/chains': 0.2.0_typescript@4.9.4
-      '@wagmi/connectors': 0.2.0_hfstv6plmtvxfkmvtsxvciubrq
+      '@wagmi/chains': 0.2.11_typescript@4.9.4
+      '@wagmi/connectors': 0.3.2_fpaddhxo5uppwziiwxtk5f5rmm
+      abitype: 0.3.0_typescript@4.9.4
+      ethers: 5.7.2
+      eventemitter3: 4.0.7
+      typescript: 4.9.4
+      zustand: 4.3.2_react@18.2.0
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@react-native-async-storage/async-storage'
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+      - bufferutil
+      - debug
+      - encoding
+      - immer
+      - lokijs
+      - react
+      - react-native
+      - supports-color
+      - utf-8-validate
+      - zod
+    dev: false
+
+  /@wagmi/core/0.9.7_2zmba3zh2lo2ye5dzgeckiacfa:
+    resolution: {integrity: sha512-9NYoxpEM+sYAv0Jg3DvMbWTnJguPwiqs61382ATU5dqMsYF1v17ngg6S15gg8oIv9Y7nYrLsiFsQ9qkNYzKlJA==}
+    peerDependencies:
+      ethers: '>=5.5.1 <6'
+      typescript: '>=4.9.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@wagmi/chains': 0.2.9_typescript@4.9.4
+      '@wagmi/connectors': 0.2.7_q3cmzdgbiw5ulsmbm3iicqs7yy
+      abitype: 0.3.0_typescript@4.9.4
+      ethers: 5.7.2
+      eventemitter3: 4.0.7
+      typescript: 4.9.4
+      zustand: 4.3.2_react@18.2.0
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@react-native-async-storage/async-storage'
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+      - bufferutil
+      - debug
+      - encoding
+      - immer
+      - lokijs
+      - react
+      - react-native
+      - supports-color
+      - utf-8-validate
+      - zod
+    dev: false
+
+  /@wagmi/core/0.9.7_fz5ualg3bc2nr2e6kzfsjxcmya:
+    resolution: {integrity: sha512-9NYoxpEM+sYAv0Jg3DvMbWTnJguPwiqs61382ATU5dqMsYF1v17ngg6S15gg8oIv9Y7nYrLsiFsQ9qkNYzKlJA==}
+    peerDependencies:
+      ethers: '>=5.5.1 <6'
+      typescript: '>=4.9.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@wagmi/chains': 0.2.9_typescript@4.9.4
+      '@wagmi/connectors': 0.2.7_ztwhwxvpdf6qmgtw3b63ds6fju
       abitype: 0.3.0_typescript@4.9.4
       ethers: 5.7.2
       eventemitter3: 4.0.7
@@ -2667,6 +2862,7 @@ packages:
 
   /@walletconnect/client/1.8.0:
     resolution: {integrity: sha512-svyBQ14NHx6Cs2j4TpkQaBI/2AF4+LXz64FojTjMtV4VMMhl81jSO1vNeg+yYhQzvjcGH/GpSwixjyCW0xFBOQ==}
+    deprecated: 'WalletConnect''s v1 SDKs are now deprecated. Please upgrade to a v2 SDK. For details see: https://docs.walletconnect.com/'
     dependencies:
       '@walletconnect/core': 1.8.0
       '@walletconnect/iso-crypto': 1.8.0
@@ -2688,21 +2884,81 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@walletconnect/core/2.3.0_typescript@4.9.4:
-    resolution: {integrity: sha512-sZ9q/6RwwCtmEBxXwQIu1lIWAtWhNYL+v1bqgGqzgcHktt2CMs6WpI8CwKEZVCH7hKYu4tmUHJYk5WHVL0RFdw==}
+  /@walletconnect/core/2.3.3_typescript@4.9.4:
+    resolution: {integrity: sha512-pkPG3f0Mb9WcWMeLtRS8+RSV9gpnAGrU0y291LNXjggDupg5H7I1hFtcj5HI0kmpk4suAS4RKqYAxPzy4MgFRQ==}
+    dependencies:
+      '@walletconnect/heartbeat': 1.2.0_typescript@4.9.4
+      '@walletconnect/jsonrpc-provider': 1.0.6
+      '@walletconnect/jsonrpc-utils': 1.0.6
+      '@walletconnect/jsonrpc-ws-connection': 1.0.10
+      '@walletconnect/keyvaluestorage': 1.0.2
+      '@walletconnect/logger': 2.0.1
+      '@walletconnect/relay-api': 1.0.9
+      '@walletconnect/relay-auth': 1.0.4
+      '@walletconnect/safe-json': 1.0.1
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.3.3_typescript@4.9.4
+      '@walletconnect/utils': 2.3.3_typescript@4.9.4
+      events: 3.3.0
+      lodash.isequal: 4.5.0
+      pino: 7.11.0
+      uint8arrays: 3.1.0
+    transitivePeerDependencies:
+      - '@react-native-async-storage/async-storage'
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+      - bufferutil
+      - lokijs
+      - typescript
+      - utf-8-validate
+    dev: false
+
+  /@walletconnect/core/2.3.3_zpb5kzpnyozdjq4cwaojlul57u:
+    resolution: {integrity: sha512-pkPG3f0Mb9WcWMeLtRS8+RSV9gpnAGrU0y291LNXjggDupg5H7I1hFtcj5HI0kmpk4suAS4RKqYAxPzy4MgFRQ==}
+    dependencies:
+      '@walletconnect/heartbeat': 1.2.0_zpb5kzpnyozdjq4cwaojlul57u
+      '@walletconnect/jsonrpc-provider': 1.0.6
+      '@walletconnect/jsonrpc-utils': 1.0.6
+      '@walletconnect/jsonrpc-ws-connection': 1.0.10
+      '@walletconnect/keyvaluestorage': 1.0.2
+      '@walletconnect/logger': 2.0.1
+      '@walletconnect/relay-api': 1.0.9
+      '@walletconnect/relay-auth': 1.0.4
+      '@walletconnect/safe-json': 1.0.1
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.3.3_zpb5kzpnyozdjq4cwaojlul57u
+      '@walletconnect/utils': 2.3.3_zpb5kzpnyozdjq4cwaojlul57u
+      events: 3.3.0
+      lodash.isequal: 4.5.0
+      pino: 7.11.0
+      uint8arrays: 3.1.0
+    transitivePeerDependencies:
+      - '@react-native-async-storage/async-storage'
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+      - bufferutil
+      - lokijs
+      - typescript
+      - utf-8-validate
+    dev: false
+
+  /@walletconnect/core/2.4.9_typescript@4.9.4:
+    resolution: {integrity: sha512-CrPs8j7earI847r1TpsFj8zij0zspQSd4OXBARLhphVvh5lv/4udcyQI77GfK0d2j6wUNla4gOBk3aKncm300A==}
     dependencies:
       '@walletconnect/heartbeat': 1.2.0_typescript@4.9.4
       '@walletconnect/jsonrpc-provider': 1.0.6
       '@walletconnect/jsonrpc-utils': 1.0.4
-      '@walletconnect/jsonrpc-ws-connection': 1.0.6
+      '@walletconnect/jsonrpc-ws-connection': 1.0.10
       '@walletconnect/keyvaluestorage': 1.0.2
       '@walletconnect/logger': 2.0.1
-      '@walletconnect/relay-api': 1.0.7
+      '@walletconnect/relay-api': 1.0.9
       '@walletconnect/relay-auth': 1.0.4
       '@walletconnect/safe-json': 1.0.1
       '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.3.0_typescript@4.9.4
-      '@walletconnect/utils': 2.3.0_typescript@4.9.4
+      '@walletconnect/types': 2.4.9_typescript@4.9.4
+      '@walletconnect/utils': 2.4.9_typescript@4.9.4
       events: 3.3.0
       lodash.isequal: 4.5.0
       pino: 7.11.0
@@ -2718,21 +2974,21 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@walletconnect/core/2.3.0_zpb5kzpnyozdjq4cwaojlul57u:
-    resolution: {integrity: sha512-sZ9q/6RwwCtmEBxXwQIu1lIWAtWhNYL+v1bqgGqzgcHktt2CMs6WpI8CwKEZVCH7hKYu4tmUHJYk5WHVL0RFdw==}
+  /@walletconnect/core/2.4.9_zpb5kzpnyozdjq4cwaojlul57u:
+    resolution: {integrity: sha512-CrPs8j7earI847r1TpsFj8zij0zspQSd4OXBARLhphVvh5lv/4udcyQI77GfK0d2j6wUNla4gOBk3aKncm300A==}
     dependencies:
       '@walletconnect/heartbeat': 1.2.0_zpb5kzpnyozdjq4cwaojlul57u
       '@walletconnect/jsonrpc-provider': 1.0.6
       '@walletconnect/jsonrpc-utils': 1.0.4
-      '@walletconnect/jsonrpc-ws-connection': 1.0.6
+      '@walletconnect/jsonrpc-ws-connection': 1.0.10
       '@walletconnect/keyvaluestorage': 1.0.2
       '@walletconnect/logger': 2.0.1
-      '@walletconnect/relay-api': 1.0.7
+      '@walletconnect/relay-api': 1.0.9
       '@walletconnect/relay-auth': 1.0.4
       '@walletconnect/safe-json': 1.0.1
       '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.3.0_zpb5kzpnyozdjq4cwaojlul57u
-      '@walletconnect/utils': 2.3.0_zpb5kzpnyozdjq4cwaojlul57u
+      '@walletconnect/types': 2.4.9_zpb5kzpnyozdjq4cwaojlul57u
+      '@walletconnect/utils': 2.4.9_zpb5kzpnyozdjq4cwaojlul57u
       events: 3.3.0
       lodash.isequal: 4.5.0
       pino: 7.11.0
@@ -2748,20 +3004,22 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@walletconnect/crypto/1.0.2:
-    resolution: {integrity: sha512-+OlNtwieUqVcOpFTvLBvH+9J9pntEqH5evpINHfVxff1XIgwV55PpbdvkHu6r9Ib4WQDOFiD8OeeXs1vHw7xKQ==}
+  /@walletconnect/crypto/1.0.3:
+    resolution: {integrity: sha512-+2jdORD7XQs76I2Odgr3wwrtyuLUXD/kprNVsjWRhhhdO9Mt6WqVzOPu0/t7OHSmgal8k7SoBQzUc5hu/8zL/g==}
     dependencies:
-      '@walletconnect/encoding': 1.0.1
+      '@walletconnect/encoding': 1.0.2
       '@walletconnect/environment': 1.0.1
-      '@walletconnect/randombytes': 1.0.2
+      '@walletconnect/randombytes': 1.0.3
       aes-js: 3.1.2
       hash.js: 1.1.7
+      tslib: 1.14.1
     dev: false
 
-  /@walletconnect/encoding/1.0.1:
-    resolution: {integrity: sha512-8opL2rs6N6E3tJfsqwS82aZQDL3gmupWUgmvuZ3CGU7z/InZs3R9jkzH8wmYtpbq0sFK3WkJkQRZFFk4BkrmFA==}
+  /@walletconnect/encoding/1.0.2:
+    resolution: {integrity: sha512-CrwSBrjqJ7rpGQcTL3kU+Ief+Bcuu9PH6JLOb+wM6NITX1GTxR/MfNwnQfhLKK6xpRAyj2/nM04OOH6wS8Imag==}
     dependencies:
       is-typedarray: 1.0.0
+      tslib: 1.14.1
       typedarray-to-buffer: 3.1.5
     dev: false
 
@@ -2773,10 +3031,11 @@ packages:
 
   /@walletconnect/ethereum-provider/1.8.0:
     resolution: {integrity: sha512-Nq9m+oo5P0F+njsROHw9KMWdoc/8iGHYzQdkjJN/1C7DtsqFRg5k5a3hd9rzCLpbPsOC1q8Z5lRs6JQgDvPm6Q==}
+    deprecated: 'WalletConnect''s v1 SDKs are now deprecated. Please upgrade to a v2 SDK. For details see: https://docs.walletconnect.com/'
     dependencies:
       '@walletconnect/client': 1.8.0
-      '@walletconnect/jsonrpc-http-connection': 1.0.3
-      '@walletconnect/jsonrpc-provider': 1.0.5
+      '@walletconnect/jsonrpc-http-connection': 1.0.4
+      '@walletconnect/jsonrpc-provider': 1.0.6
       '@walletconnect/signer-connection': 1.8.0
       '@walletconnect/types': 1.8.0
       '@walletconnect/utils': 1.8.0
@@ -2786,6 +3045,60 @@ packages:
       - bufferutil
       - debug
       - encoding
+      - utf-8-validate
+    dev: false
+
+  /@walletconnect/ethereum-provider/2.4.9_ccd6e3ud4g73fwcdmw2hfpovvi:
+    resolution: {integrity: sha512-WEbcgr54DsuztUcYz4guzSF/D5D5K5m3NWNCbVuElY6Veei+90KSKK21Jn6HINUUXbhjgFLlFiS4PevLNA5ceA==}
+    dependencies:
+      '@walletconnect/jsonrpc-http-connection': 1.0.4
+      '@walletconnect/jsonrpc-provider': 1.0.6
+      '@walletconnect/jsonrpc-types': 1.0.2
+      '@walletconnect/jsonrpc-utils': 1.0.4
+      '@walletconnect/sign-client': 2.4.9_zpb5kzpnyozdjq4cwaojlul57u
+      '@walletconnect/types': 2.4.9_zpb5kzpnyozdjq4cwaojlul57u
+      '@walletconnect/universal-provider': 2.4.9_zpb5kzpnyozdjq4cwaojlul57u
+      '@walletconnect/utils': 2.4.9_zpb5kzpnyozdjq4cwaojlul57u
+      '@web3modal/standalone': 2.2.0_react@18.2.0
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@react-native-async-storage/async-storage'
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+      - bufferutil
+      - debug
+      - encoding
+      - lokijs
+      - react
+      - typescript
+      - utf-8-validate
+    dev: false
+
+  /@walletconnect/ethereum-provider/2.4.9_o77wnou4wwnegu5woljtklrzru:
+    resolution: {integrity: sha512-WEbcgr54DsuztUcYz4guzSF/D5D5K5m3NWNCbVuElY6Veei+90KSKK21Jn6HINUUXbhjgFLlFiS4PevLNA5ceA==}
+    dependencies:
+      '@walletconnect/jsonrpc-http-connection': 1.0.4
+      '@walletconnect/jsonrpc-provider': 1.0.6
+      '@walletconnect/jsonrpc-types': 1.0.2
+      '@walletconnect/jsonrpc-utils': 1.0.4
+      '@walletconnect/sign-client': 2.4.9_typescript@4.9.4
+      '@walletconnect/types': 2.4.9_typescript@4.9.4
+      '@walletconnect/universal-provider': 2.4.9_typescript@4.9.4
+      '@walletconnect/utils': 2.4.9_typescript@4.9.4
+      '@web3modal/standalone': 2.2.0_react@18.2.0
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@react-native-async-storage/async-storage'
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+      - bufferutil
+      - debug
+      - encoding
+      - lokijs
+      - react
+      - typescript
       - utf-8-validate
     dev: false
 
@@ -2831,19 +3144,9 @@ packages:
   /@walletconnect/iso-crypto/1.8.0:
     resolution: {integrity: sha512-pWy19KCyitpfXb70hA73r9FcvklS+FvO9QUIttp3c2mfW8frxgYeRXfxLRCIQTkaYueRKvdqPjbyhPLam508XQ==}
     dependencies:
-      '@walletconnect/crypto': 1.0.2
+      '@walletconnect/crypto': 1.0.3
       '@walletconnect/types': 1.8.0
       '@walletconnect/utils': 1.8.0
-    dev: false
-
-  /@walletconnect/jsonrpc-http-connection/1.0.3:
-    resolution: {integrity: sha512-npPvDG2JxyxoqOphDiyjp5pPeASRBrlfQS39wHESPHlFIjBuvNt9lV9teh53MK9Ncbyxh4y2qEKMfPgcUulTRg==}
-    dependencies:
-      '@walletconnect/jsonrpc-utils': 1.0.3
-      '@walletconnect/safe-json': 1.0.0
-      cross-fetch: 3.1.5
-    transitivePeerDependencies:
-      - encoding
     dev: false
 
   /@walletconnect/jsonrpc-http-connection/1.0.4:
@@ -2857,13 +3160,6 @@ packages:
       - encoding
     dev: false
 
-  /@walletconnect/jsonrpc-provider/1.0.5:
-    resolution: {integrity: sha512-v61u4ZIV8+p9uIHS2Kl2YRj/2idrQiHcrbrJXw3McQkEJtj9mkCofr1Hu/n419wSRM5uiNK8Z4WRS9zGTTAhWQ==}
-    dependencies:
-      '@walletconnect/jsonrpc-utils': 1.0.3
-      '@walletconnect/safe-json': 1.0.0
-    dev: false
-
   /@walletconnect/jsonrpc-provider/1.0.6:
     resolution: {integrity: sha512-f5vQxr53vUVQ51/9mRLb1OiNciT/546XZ68Byn9OYnDBGeGJXK2kQWDHp8sPWZbN5x0p7B6asdCWMVFJ6danlw==}
     dependencies:
@@ -2872,24 +3168,11 @@ packages:
       tslib: 1.14.1
     dev: false
 
-  /@walletconnect/jsonrpc-types/1.0.1:
-    resolution: {integrity: sha512-+6coTtOuChCqM+AoYyi4Q83p9l/laI6NvuM2/AHaZFuf0gT0NjW7IX2+86qGyizn7Ptq4AYZmfxurAxTnhefuw==}
-    dependencies:
-      keyvaluestorage-interface: 1.0.0
-    dev: false
-
   /@walletconnect/jsonrpc-types/1.0.2:
     resolution: {integrity: sha512-CZe8tjJX73OWdHjrBHy7HtAapJ2tT0Q3TYhPBhRxi3643lwPIQWC9En45ldY14TZwgSewkbZ0FtGBZK0G7Bbyg==}
     dependencies:
       keyvaluestorage-interface: 1.0.0
       tslib: 1.14.1
-    dev: false
-
-  /@walletconnect/jsonrpc-utils/1.0.3:
-    resolution: {integrity: sha512-3yb49bPk16MNLk6uIIHPSHQCpD6UAo1OMOx1rM8cW/MPEAYAzrSW5hkhG7NEUwX9SokRIgnZK3QuQkiyNzBMhQ==}
-    dependencies:
-      '@walletconnect/environment': 1.0.1
-      '@walletconnect/jsonrpc-types': 1.0.2
     dev: false
 
   /@walletconnect/jsonrpc-utils/1.0.4:
@@ -2900,10 +3183,18 @@ packages:
       tslib: 1.14.1
     dev: false
 
-  /@walletconnect/jsonrpc-ws-connection/1.0.6:
-    resolution: {integrity: sha512-WFu8uTXbIDgxFfyax9uNcqFYtexUq/OdCA3SBsOqIipsnJFbjXK8OaR8WCoec4tkJbDRQO9mrr1KpA0ZlIcnCQ==}
+  /@walletconnect/jsonrpc-utils/1.0.6:
+    resolution: {integrity: sha512-snp0tfkjPiDLQp/jrBewI+9SM33GPV4+Gjgldod6XQ7rFyQ5FZjnBxUkY4xWH0+arNxzQSi6v5iDXjCjSaorpg==}
     dependencies:
-      '@walletconnect/jsonrpc-utils': 1.0.4
+      '@walletconnect/environment': 1.0.1
+      '@walletconnect/jsonrpc-types': 1.0.2
+      tslib: 1.14.1
+    dev: false
+
+  /@walletconnect/jsonrpc-ws-connection/1.0.10:
+    resolution: {integrity: sha512-/tidvjfCXZuYugjF5fOswsNDPoMo9QRML3DFQ0dfNUarL4f5HGqu8NDGerr2n0+4MOX23GsT6Vv2POSwFbvgGw==}
+    dependencies:
+      '@walletconnect/jsonrpc-utils': 1.0.6
       '@walletconnect/safe-json': 1.0.1
       events: 3.3.0
       tslib: 1.14.1
@@ -2928,6 +3219,63 @@ packages:
       tslib: 1.14.1
     dev: false
 
+  /@walletconnect/legacy-client/2.0.0:
+    resolution: {integrity: sha512-v5L7rYk9loVnfvUf0mF+76bUPFaU5/Vh7mzL6/950CD/yoGdzYZ3Kj+L7mkC6HPMEGeQsBP1+sqBuiVGZ/aODA==}
+    dependencies:
+      '@walletconnect/crypto': 1.0.3
+      '@walletconnect/encoding': 1.0.2
+      '@walletconnect/jsonrpc-utils': 1.0.4
+      '@walletconnect/legacy-types': 2.0.0
+      '@walletconnect/legacy-utils': 2.0.0
+      '@walletconnect/safe-json': 1.0.1
+      '@walletconnect/window-getters': 1.0.1
+      '@walletconnect/window-metadata': 1.0.1
+      detect-browser: 5.3.0
+      query-string: 6.13.5
+    dev: false
+
+  /@walletconnect/legacy-modal/2.0.0:
+    resolution: {integrity: sha512-jckNd8lMhm4X7dX9TDdxM3bXKJnaqkRs6K2Mo5j6GmbIF9Eyx40jZ5+q457RVxvM6ciZEDT5s1wBHWdWoOo+9Q==}
+    dependencies:
+      '@walletconnect/legacy-types': 2.0.0
+      '@walletconnect/legacy-utils': 2.0.0
+      copy-to-clipboard: 3.3.3
+      preact: 10.13.1
+      qrcode: 1.5.1
+    dev: false
+
+  /@walletconnect/legacy-provider/2.0.0:
+    resolution: {integrity: sha512-A8xPebMI1A+50HbWwTpFCbwP7G+1NGKdTKyg8BUUg3h3Y9JucpC1W6w/x0v1Xw7qFEqQnz74LoIN/A3ytH9xrQ==}
+    dependencies:
+      '@walletconnect/jsonrpc-http-connection': 1.0.4
+      '@walletconnect/jsonrpc-provider': 1.0.6
+      '@walletconnect/legacy-client': 2.0.0
+      '@walletconnect/legacy-modal': 2.0.0
+      '@walletconnect/legacy-types': 2.0.0
+      '@walletconnect/legacy-utils': 2.0.0
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
+  /@walletconnect/legacy-types/2.0.0:
+    resolution: {integrity: sha512-sOVrA7HUdbI1OwKyPOQU0/DdvTSVFlsXWpAk2K2WvP2erTkBWPMTJq6cv2BmKdoJ3p6gLApT7sd+jHi3OF71uw==}
+    dependencies:
+      '@walletconnect/jsonrpc-types': 1.0.2
+    dev: false
+
+  /@walletconnect/legacy-utils/2.0.0:
+    resolution: {integrity: sha512-CPWxSVVXw0kgNCxvU126g4GiV3mzXmC8IPJ15twE46aJ1FX+RHEIfAzFMFz2F2+fEhBxL63A7dwNQKDXorRPcQ==}
+    dependencies:
+      '@walletconnect/encoding': 1.0.2
+      '@walletconnect/jsonrpc-utils': 1.0.4
+      '@walletconnect/legacy-types': 2.0.0
+      '@walletconnect/safe-json': 1.0.1
+      '@walletconnect/window-getters': 1.0.1
+      '@walletconnect/window-metadata': 1.0.1
+      detect-browser: 5.3.0
+      query-string: 6.13.5
+    dev: false
+
   /@walletconnect/logger/2.0.1:
     resolution: {integrity: sha512-SsTKdsgWm+oDTBeNE/zHxxr5eJfZmE9/5yp/Ku+zJtcTAjELb3DXueWkDXmE9h8uHIbJzIb5wj5lPdzyrjT6hQ==}
     dependencies:
@@ -2942,6 +3290,7 @@ packages:
 
   /@walletconnect/qrcode-modal/1.8.0:
     resolution: {integrity: sha512-BueaFefaAi8mawE45eUtztg3ZFbsAH4DDXh1UNwdUlsvFMjqcYzLUG0xZvDd6z2eOpbgDg2N3bl6gF0KONj1dg==}
+    deprecated: 'WalletConnect''s v1 SDKs are now deprecated. Please upgrade to a v2 SDK. For details see: https://docs.walletconnect.com/'
     dependencies:
       '@walletconnect/browser-utils': 1.8.0
       '@walletconnect/mobile-registry': 1.4.0
@@ -2951,16 +3300,17 @@ packages:
       qrcode: 1.4.4
     dev: false
 
-  /@walletconnect/randombytes/1.0.2:
-    resolution: {integrity: sha512-ivgOtAyqQnN0rLQmOFPemsgYGysd/ooLfaDA/ACQ3cyqlca56t3rZc7pXfqJOIETx/wSyoF5XbwL+BqYodw27A==}
+  /@walletconnect/randombytes/1.0.3:
+    resolution: {integrity: sha512-35lpzxcHFbTN3ABefC9W+uBpNZl1GC4Wpx0ed30gibfO/y9oLdy1NznbV96HARQKSBV9J9M/rrtIvf6a23jfYw==}
     dependencies:
-      '@walletconnect/encoding': 1.0.1
+      '@walletconnect/encoding': 1.0.2
       '@walletconnect/environment': 1.0.1
       randombytes: 2.1.0
+      tslib: 1.14.1
     dev: false
 
-  /@walletconnect/relay-api/1.0.7:
-    resolution: {integrity: sha512-Mf/Ql7Z0waZzAuondHS9bbUi12Kyvl95ihxVDM7mPO8o7Ke7S1ffpujCUhXbSacSKcw9aV2+7bKADlsBjQLR5Q==}
+  /@walletconnect/relay-api/1.0.9:
+    resolution: {integrity: sha512-Q3+rylJOqRkO1D9Su0DPE3mmznbAalYapJ9qmzDgK28mYF9alcP3UwG/og5V7l7CFOqzCLi7B8BvcBUrpDj0Rg==}
     dependencies:
       '@walletconnect/jsonrpc-types': 1.0.2
       tslib: 1.14.1
@@ -2987,18 +3337,18 @@ packages:
       tslib: 1.14.1
     dev: false
 
-  /@walletconnect/sign-client/2.3.0_typescript@4.9.4:
-    resolution: {integrity: sha512-SM0qup3zhwu2sGMl1540ts6GYYy6T6Bg80ywXjp+VjkaXaxwThIl//WEIo+2vHWQItLbcgue1W/EXOXCmky8pg==}
+  /@walletconnect/sign-client/2.3.3_typescript@4.9.4:
+    resolution: {integrity: sha512-Q+KiqYYecf9prJoQWLIV7zJcEPa69XBzwrad4sQPcDD1BZMWa1f8OZUH3HmlmuCzopqEr4mgXU6v6yFHOasADw==}
     dependencies:
-      '@walletconnect/core': 2.3.0_typescript@4.9.4
+      '@walletconnect/core': 2.3.3_typescript@4.9.4
       '@walletconnect/events': 1.0.1
       '@walletconnect/heartbeat': 1.2.0_typescript@4.9.4
       '@walletconnect/jsonrpc-provider': 1.0.6
-      '@walletconnect/jsonrpc-utils': 1.0.4
+      '@walletconnect/jsonrpc-utils': 1.0.6
       '@walletconnect/logger': 2.0.1
       '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.3.0_typescript@4.9.4
-      '@walletconnect/utils': 2.3.0_typescript@4.9.4
+      '@walletconnect/types': 2.3.3_typescript@4.9.4
+      '@walletconnect/utils': 2.3.3_typescript@4.9.4
       events: 3.3.0
       pino: 7.11.0
     transitivePeerDependencies:
@@ -3012,18 +3362,68 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@walletconnect/sign-client/2.3.0_zpb5kzpnyozdjq4cwaojlul57u:
-    resolution: {integrity: sha512-SM0qup3zhwu2sGMl1540ts6GYYy6T6Bg80ywXjp+VjkaXaxwThIl//WEIo+2vHWQItLbcgue1W/EXOXCmky8pg==}
+  /@walletconnect/sign-client/2.3.3_zpb5kzpnyozdjq4cwaojlul57u:
+    resolution: {integrity: sha512-Q+KiqYYecf9prJoQWLIV7zJcEPa69XBzwrad4sQPcDD1BZMWa1f8OZUH3HmlmuCzopqEr4mgXU6v6yFHOasADw==}
     dependencies:
-      '@walletconnect/core': 2.3.0_zpb5kzpnyozdjq4cwaojlul57u
+      '@walletconnect/core': 2.3.3_zpb5kzpnyozdjq4cwaojlul57u
+      '@walletconnect/events': 1.0.1
+      '@walletconnect/heartbeat': 1.2.0_zpb5kzpnyozdjq4cwaojlul57u
+      '@walletconnect/jsonrpc-provider': 1.0.6
+      '@walletconnect/jsonrpc-utils': 1.0.6
+      '@walletconnect/logger': 2.0.1
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.3.3_zpb5kzpnyozdjq4cwaojlul57u
+      '@walletconnect/utils': 2.3.3_zpb5kzpnyozdjq4cwaojlul57u
+      events: 3.3.0
+      pino: 7.11.0
+    transitivePeerDependencies:
+      - '@react-native-async-storage/async-storage'
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+      - bufferutil
+      - lokijs
+      - typescript
+      - utf-8-validate
+    dev: false
+
+  /@walletconnect/sign-client/2.4.9_typescript@4.9.4:
+    resolution: {integrity: sha512-9O6Z2qqQ5eo/BlneAMci1AF/5hW+kpnsW8mXjrTEF2pT9IgpA5lq16fdM7D3AP01udSA0Mu4K0LFX3Qa1QbmSA==}
+    dependencies:
+      '@walletconnect/core': 2.4.9_typescript@4.9.4
+      '@walletconnect/events': 1.0.1
+      '@walletconnect/heartbeat': 1.2.0_typescript@4.9.4
+      '@walletconnect/jsonrpc-provider': 1.0.6
+      '@walletconnect/jsonrpc-utils': 1.0.4
+      '@walletconnect/logger': 2.0.1
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.4.9_typescript@4.9.4
+      '@walletconnect/utils': 2.4.9_typescript@4.9.4
+      events: 3.3.0
+      pino: 7.11.0
+    transitivePeerDependencies:
+      - '@react-native-async-storage/async-storage'
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+      - bufferutil
+      - lokijs
+      - typescript
+      - utf-8-validate
+    dev: false
+
+  /@walletconnect/sign-client/2.4.9_zpb5kzpnyozdjq4cwaojlul57u:
+    resolution: {integrity: sha512-9O6Z2qqQ5eo/BlneAMci1AF/5hW+kpnsW8mXjrTEF2pT9IgpA5lq16fdM7D3AP01udSA0Mu4K0LFX3Qa1QbmSA==}
+    dependencies:
+      '@walletconnect/core': 2.4.9_zpb5kzpnyozdjq4cwaojlul57u
       '@walletconnect/events': 1.0.1
       '@walletconnect/heartbeat': 1.2.0_zpb5kzpnyozdjq4cwaojlul57u
       '@walletconnect/jsonrpc-provider': 1.0.6
       '@walletconnect/jsonrpc-utils': 1.0.4
       '@walletconnect/logger': 2.0.1
       '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.3.0_zpb5kzpnyozdjq4cwaojlul57u
-      '@walletconnect/utils': 2.3.0_zpb5kzpnyozdjq4cwaojlul57u
+      '@walletconnect/types': 2.4.9_zpb5kzpnyozdjq4cwaojlul57u
+      '@walletconnect/utils': 2.4.9_zpb5kzpnyozdjq4cwaojlul57u
       events: 3.3.0
       pino: 7.11.0
     transitivePeerDependencies:
@@ -3041,8 +3441,8 @@ packages:
     resolution: {integrity: sha512-+YAaTAP52MWZJ2wWnqKClKCPlPHBo6reURFe0cWidLADh9mi/kPWGALZ5AENK22zpem1bbKV466rF5Rzvu0ehA==}
     dependencies:
       '@walletconnect/client': 1.8.0
-      '@walletconnect/jsonrpc-types': 1.0.1
-      '@walletconnect/jsonrpc-utils': 1.0.3
+      '@walletconnect/jsonrpc-types': 1.0.2
+      '@walletconnect/jsonrpc-utils': 1.0.6
       '@walletconnect/qrcode-modal': 1.8.0
       '@walletconnect/types': 1.8.0
       eventemitter3: 4.0.7
@@ -3070,10 +3470,11 @@ packages:
 
   /@walletconnect/types/1.8.0:
     resolution: {integrity: sha512-Cn+3I0V0vT9ghMuzh1KzZvCkiAxTq+1TR2eSqw5E5AVWfmCtECFkVZBP6uUJZ8YjwLqXheI+rnjqPy7sVM4Fyg==}
+    deprecated: 'WalletConnect''s v1 SDKs are now deprecated. Please upgrade to a v2 SDK. For details see: https://docs.walletconnect.com/'
     dev: false
 
-  /@walletconnect/types/2.3.0_typescript@4.9.4:
-    resolution: {integrity: sha512-+RyEjwcBlY0kywmVbnTf11ps0jT3rev2kqvhjtOKIhHjfzPzptqGPpmk8VRthvh0ZasDccmOVWBaEi79bGFInw==}
+  /@walletconnect/types/2.3.3_typescript@4.9.4:
+    resolution: {integrity: sha512-g2x27MloGElcRTwYM9Md/1E2RQ5ifYBCFZ/sfnpQrZPVxK3NzSMHJlcV6qrQm9ST82i+UrLEce9RkDgvjKk7+w==}
     dependencies:
       '@walletconnect/events': 1.0.1
       '@walletconnect/heartbeat': 1.2.0_typescript@4.9.4
@@ -3090,8 +3491,8 @@ packages:
       - typescript
     dev: false
 
-  /@walletconnect/types/2.3.0_zpb5kzpnyozdjq4cwaojlul57u:
-    resolution: {integrity: sha512-+RyEjwcBlY0kywmVbnTf11ps0jT3rev2kqvhjtOKIhHjfzPzptqGPpmk8VRthvh0ZasDccmOVWBaEi79bGFInw==}
+  /@walletconnect/types/2.3.3_zpb5kzpnyozdjq4cwaojlul57u:
+    resolution: {integrity: sha512-g2x27MloGElcRTwYM9Md/1E2RQ5ifYBCFZ/sfnpQrZPVxK3NzSMHJlcV6qrQm9ST82i+UrLEce9RkDgvjKk7+w==}
     dependencies:
       '@walletconnect/events': 1.0.1
       '@walletconnect/heartbeat': 1.2.0_zpb5kzpnyozdjq4cwaojlul57u
@@ -3108,17 +3509,53 @@ packages:
       - typescript
     dev: false
 
-  /@walletconnect/universal-provider/2.3.0_typescript@4.9.4:
-    resolution: {integrity: sha512-7PdRI/mIVAt7F4PvDBm4rQp8FWXxiMeRNNnkMd8Ot2qkVmSd8EhxBKD9lHLVlvv8RZ8zmq7fra/ISwx5ZU6HAg==}
+  /@walletconnect/types/2.4.9_typescript@4.9.4:
+    resolution: {integrity: sha512-Mv1yH8MI52JPBi1Qj/iDjMewjBVhy4TrWPiPrSU0zcUSpUzCmai/BxGMjEGOJ8gsEIFwfEkFkZJQoza2fVtFLA==}
+    dependencies:
+      '@walletconnect/events': 1.0.1
+      '@walletconnect/heartbeat': 1.2.0_typescript@4.9.4
+      '@walletconnect/jsonrpc-types': 1.0.2
+      '@walletconnect/keyvaluestorage': 1.0.2
+      '@walletconnect/logger': 2.0.1
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@react-native-async-storage/async-storage'
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+      - lokijs
+      - typescript
+    dev: false
+
+  /@walletconnect/types/2.4.9_zpb5kzpnyozdjq4cwaojlul57u:
+    resolution: {integrity: sha512-Mv1yH8MI52JPBi1Qj/iDjMewjBVhy4TrWPiPrSU0zcUSpUzCmai/BxGMjEGOJ8gsEIFwfEkFkZJQoza2fVtFLA==}
+    dependencies:
+      '@walletconnect/events': 1.0.1
+      '@walletconnect/heartbeat': 1.2.0_zpb5kzpnyozdjq4cwaojlul57u
+      '@walletconnect/jsonrpc-types': 1.0.2
+      '@walletconnect/keyvaluestorage': 1.0.2
+      '@walletconnect/logger': 2.0.1
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@react-native-async-storage/async-storage'
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+      - lokijs
+      - typescript
+    dev: false
+
+  /@walletconnect/universal-provider/2.3.3_typescript@4.9.4:
+    resolution: {integrity: sha512-pibtlTUn7dg5Y5vs8tzSGaaDlq8eSXgHh7o9iMMpE4Fr06HyM36J0niGTOsKvMa+u5keCTwVhbB4MNnN08zVvg==}
     dependencies:
       '@walletconnect/jsonrpc-http-connection': 1.0.4
       '@walletconnect/jsonrpc-provider': 1.0.6
       '@walletconnect/jsonrpc-types': 1.0.2
-      '@walletconnect/jsonrpc-utils': 1.0.4
+      '@walletconnect/jsonrpc-utils': 1.0.6
       '@walletconnect/logger': 2.0.1
-      '@walletconnect/sign-client': 2.3.0_typescript@4.9.4
-      '@walletconnect/types': 2.3.0_typescript@4.9.4
-      '@walletconnect/utils': 2.3.0_typescript@4.9.4
+      '@walletconnect/sign-client': 2.3.3_typescript@4.9.4
+      '@walletconnect/types': 2.3.3_typescript@4.9.4
+      '@walletconnect/utils': 2.3.3_typescript@4.9.4
       eip1193-provider: 1.0.1
       events: 3.3.0
       pino: 7.11.0
@@ -3135,17 +3572,71 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@walletconnect/universal-provider/2.3.0_zpb5kzpnyozdjq4cwaojlul57u:
-    resolution: {integrity: sha512-7PdRI/mIVAt7F4PvDBm4rQp8FWXxiMeRNNnkMd8Ot2qkVmSd8EhxBKD9lHLVlvv8RZ8zmq7fra/ISwx5ZU6HAg==}
+  /@walletconnect/universal-provider/2.3.3_zpb5kzpnyozdjq4cwaojlul57u:
+    resolution: {integrity: sha512-pibtlTUn7dg5Y5vs8tzSGaaDlq8eSXgHh7o9iMMpE4Fr06HyM36J0niGTOsKvMa+u5keCTwVhbB4MNnN08zVvg==}
+    dependencies:
+      '@walletconnect/jsonrpc-http-connection': 1.0.4
+      '@walletconnect/jsonrpc-provider': 1.0.6
+      '@walletconnect/jsonrpc-types': 1.0.2
+      '@walletconnect/jsonrpc-utils': 1.0.6
+      '@walletconnect/logger': 2.0.1
+      '@walletconnect/sign-client': 2.3.3_zpb5kzpnyozdjq4cwaojlul57u
+      '@walletconnect/types': 2.3.3_zpb5kzpnyozdjq4cwaojlul57u
+      '@walletconnect/utils': 2.3.3_zpb5kzpnyozdjq4cwaojlul57u
+      eip1193-provider: 1.0.1
+      events: 3.3.0
+      pino: 7.11.0
+    transitivePeerDependencies:
+      - '@react-native-async-storage/async-storage'
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+      - bufferutil
+      - debug
+      - encoding
+      - lokijs
+      - typescript
+      - utf-8-validate
+    dev: false
+
+  /@walletconnect/universal-provider/2.4.9_typescript@4.9.4:
+    resolution: {integrity: sha512-UZBNX86Fc9WJXyJtRHp/J8zNaH4H6MIgHaNVqlejKyDSi2q7iqAnFEbueXmqsyzW07lAi2q+hnc7zGpOgMCnhA==}
     dependencies:
       '@walletconnect/jsonrpc-http-connection': 1.0.4
       '@walletconnect/jsonrpc-provider': 1.0.6
       '@walletconnect/jsonrpc-types': 1.0.2
       '@walletconnect/jsonrpc-utils': 1.0.4
       '@walletconnect/logger': 2.0.1
-      '@walletconnect/sign-client': 2.3.0_zpb5kzpnyozdjq4cwaojlul57u
-      '@walletconnect/types': 2.3.0_zpb5kzpnyozdjq4cwaojlul57u
-      '@walletconnect/utils': 2.3.0_zpb5kzpnyozdjq4cwaojlul57u
+      '@walletconnect/sign-client': 2.4.9_typescript@4.9.4
+      '@walletconnect/types': 2.4.9_typescript@4.9.4
+      '@walletconnect/utils': 2.4.9_typescript@4.9.4
+      eip1193-provider: 1.0.1
+      events: 3.3.0
+      pino: 7.11.0
+    transitivePeerDependencies:
+      - '@react-native-async-storage/async-storage'
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+      - bufferutil
+      - debug
+      - encoding
+      - lokijs
+      - typescript
+      - utf-8-validate
+    dev: false
+
+  /@walletconnect/universal-provider/2.4.9_zpb5kzpnyozdjq4cwaojlul57u:
+    resolution: {integrity: sha512-UZBNX86Fc9WJXyJtRHp/J8zNaH4H6MIgHaNVqlejKyDSi2q7iqAnFEbueXmqsyzW07lAi2q+hnc7zGpOgMCnhA==}
+    dependencies:
+      '@walletconnect/jsonrpc-http-connection': 1.0.4
+      '@walletconnect/jsonrpc-provider': 1.0.6
+      '@walletconnect/jsonrpc-types': 1.0.2
+      '@walletconnect/jsonrpc-utils': 1.0.4
+      '@walletconnect/logger': 2.0.1
+      '@walletconnect/sign-client': 2.4.9_zpb5kzpnyozdjq4cwaojlul57u
+      '@walletconnect/types': 2.4.9_zpb5kzpnyozdjq4cwaojlul57u
+      '@walletconnect/utils': 2.4.9_zpb5kzpnyozdjq4cwaojlul57u
       eip1193-provider: 1.0.1
       events: 3.3.0
       pino: 7.11.0
@@ -3166,27 +3657,27 @@ packages:
     resolution: {integrity: sha512-zExzp8Mj1YiAIBfKNm5u622oNw44WOESzo6hj+Q3apSMIb0Jph9X3GDIdbZmvVZsNPxWDL7uodKgZcCInZv2vA==}
     dependencies:
       '@walletconnect/browser-utils': 1.8.0
-      '@walletconnect/encoding': 1.0.1
-      '@walletconnect/jsonrpc-utils': 1.0.3
+      '@walletconnect/encoding': 1.0.2
+      '@walletconnect/jsonrpc-utils': 1.0.6
       '@walletconnect/types': 1.8.0
       bn.js: 4.11.8
       js-sha3: 0.8.0
       query-string: 6.13.5
     dev: false
 
-  /@walletconnect/utils/2.3.0_typescript@4.9.4:
-    resolution: {integrity: sha512-HMpXmxjioleu+7qH+jRMfhO45AkChGCw4eSKyskkPslAeg2TaMQEVrZp53/Dbb1lunwS/5flL6s53SyLUneNLQ==}
+  /@walletconnect/utils/2.3.3_typescript@4.9.4:
+    resolution: {integrity: sha512-wS9ptLlT30c7m7zme3/y3cNjKXztZeKIulqBD1K/VxSxWEA4mK9mmXEACdmahjiX4EHZWtdHvEIu2rLDhkrrvQ==}
     dependencies:
       '@stablelib/chacha20poly1305': 1.0.1
       '@stablelib/hkdf': 1.0.1
       '@stablelib/random': 1.0.2
       '@stablelib/sha256': 1.0.1
       '@stablelib/x25519': 1.0.3
-      '@walletconnect/jsonrpc-utils': 1.0.4
-      '@walletconnect/relay-api': 1.0.7
+      '@walletconnect/jsonrpc-utils': 1.0.6
+      '@walletconnect/relay-api': 1.0.9
       '@walletconnect/safe-json': 1.0.1
       '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.3.0_typescript@4.9.4
+      '@walletconnect/types': 2.3.3_typescript@4.9.4
       '@walletconnect/window-getters': 1.0.1
       '@walletconnect/window-metadata': 1.0.1
       detect-browser: 5.3.0
@@ -3201,8 +3692,35 @@ packages:
       - typescript
     dev: false
 
-  /@walletconnect/utils/2.3.0_zpb5kzpnyozdjq4cwaojlul57u:
-    resolution: {integrity: sha512-HMpXmxjioleu+7qH+jRMfhO45AkChGCw4eSKyskkPslAeg2TaMQEVrZp53/Dbb1lunwS/5flL6s53SyLUneNLQ==}
+  /@walletconnect/utils/2.3.3_zpb5kzpnyozdjq4cwaojlul57u:
+    resolution: {integrity: sha512-wS9ptLlT30c7m7zme3/y3cNjKXztZeKIulqBD1K/VxSxWEA4mK9mmXEACdmahjiX4EHZWtdHvEIu2rLDhkrrvQ==}
+    dependencies:
+      '@stablelib/chacha20poly1305': 1.0.1
+      '@stablelib/hkdf': 1.0.1
+      '@stablelib/random': 1.0.2
+      '@stablelib/sha256': 1.0.1
+      '@stablelib/x25519': 1.0.3
+      '@walletconnect/jsonrpc-utils': 1.0.6
+      '@walletconnect/relay-api': 1.0.9
+      '@walletconnect/safe-json': 1.0.1
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.3.3_zpb5kzpnyozdjq4cwaojlul57u
+      '@walletconnect/window-getters': 1.0.1
+      '@walletconnect/window-metadata': 1.0.1
+      detect-browser: 5.3.0
+      query-string: 7.1.1
+      uint8arrays: 3.1.0
+    transitivePeerDependencies:
+      - '@react-native-async-storage/async-storage'
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+      - lokijs
+      - typescript
+    dev: false
+
+  /@walletconnect/utils/2.4.9_typescript@4.9.4:
+    resolution: {integrity: sha512-Mq5ZgXAn/SJZJYkINkl07YprnuvFRi+A7c3wapgvKjFB6msFMllBa4UFukON5+5ZCScSwPMwxoUX4EBjWnbaWA==}
     dependencies:
       '@stablelib/chacha20poly1305': 1.0.1
       '@stablelib/hkdf': 1.0.1
@@ -3210,10 +3728,37 @@ packages:
       '@stablelib/sha256': 1.0.1
       '@stablelib/x25519': 1.0.3
       '@walletconnect/jsonrpc-utils': 1.0.4
-      '@walletconnect/relay-api': 1.0.7
+      '@walletconnect/relay-api': 1.0.9
       '@walletconnect/safe-json': 1.0.1
       '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.3.0_zpb5kzpnyozdjq4cwaojlul57u
+      '@walletconnect/types': 2.4.9_typescript@4.9.4
+      '@walletconnect/window-getters': 1.0.1
+      '@walletconnect/window-metadata': 1.0.1
+      detect-browser: 5.3.0
+      query-string: 7.1.1
+      uint8arrays: 3.1.0
+    transitivePeerDependencies:
+      - '@react-native-async-storage/async-storage'
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+      - lokijs
+      - typescript
+    dev: false
+
+  /@walletconnect/utils/2.4.9_zpb5kzpnyozdjq4cwaojlul57u:
+    resolution: {integrity: sha512-Mq5ZgXAn/SJZJYkINkl07YprnuvFRi+A7c3wapgvKjFB6msFMllBa4UFukON5+5ZCScSwPMwxoUX4EBjWnbaWA==}
+    dependencies:
+      '@stablelib/chacha20poly1305': 1.0.1
+      '@stablelib/hkdf': 1.0.1
+      '@stablelib/random': 1.0.2
+      '@stablelib/sha256': 1.0.1
+      '@stablelib/x25519': 1.0.3
+      '@walletconnect/jsonrpc-utils': 1.0.4
+      '@walletconnect/relay-api': 1.0.9
+      '@walletconnect/safe-json': 1.0.1
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.4.9_zpb5kzpnyozdjq4cwaojlul57u
       '@walletconnect/window-getters': 1.0.1
       '@walletconnect/window-metadata': 1.0.1
       detect-browser: 5.3.0
@@ -3251,36 +3796,8 @@ packages:
       tslib: 1.14.1
     dev: false
 
-  /@web3modal/core/2.0.0-beta.6_react@18.2.0:
-    resolution: {integrity: sha512-YiU+Cp3nHwwkm9qgFyWum04ySYgKExCkj5N+XJNNsnSLScGhgEa2gSiP5u198S5H11k9q4PTNFZge3s+zNLj8w==}
-    dependencies:
-      buffer: 6.0.3
-      valtio: 1.7.6_react@18.2.0
-    transitivePeerDependencies:
-      - '@babel/helper-module-imports'
-      - '@babel/types'
-      - aslemammad-vite-plugin-macro
-      - babel-plugin-macros
-      - react
-      - vite
-    dev: false
-
-  /@web3modal/core/2.0.0-beta.6_react@18.2.0+vite@3.2.4:
-    resolution: {integrity: sha512-YiU+Cp3nHwwkm9qgFyWum04ySYgKExCkj5N+XJNNsnSLScGhgEa2gSiP5u198S5H11k9q4PTNFZge3s+zNLj8w==}
-    dependencies:
-      buffer: 6.0.3
-      valtio: 1.7.6_react@18.2.0+vite@3.2.4
-    transitivePeerDependencies:
-      - '@babel/helper-module-imports'
-      - '@babel/types'
-      - aslemammad-vite-plugin-macro
-      - babel-plugin-macros
-      - react
-      - vite
-    dev: false
-
-  /@web3modal/core/2.0.0_react@18.2.0:
-    resolution: {integrity: sha512-ZoM3U5DndBAVnnkBJ3hIkOKO81VtWfyda458D1vdN/T6q8IoWzWZR5QHZNc1qNKqm7ecXfEpsPj2YMS3bgOY2A==}
+  /@web3modal/core/2.2.0_react@18.2.0:
+    resolution: {integrity: sha512-Kafg/KtK6S9x0Ofcaq9hj7dRK5/541nM+LnayPmHxx4fSrDgcM9YYhL12fI4BG1xGOJwkeZjgFOtS0qf123Cjw==}
     dependencies:
       buffer: 6.0.3
       valtio: 1.9.0_react@18.2.0
@@ -3288,106 +3805,40 @@ packages:
       - react
     dev: false
 
-  /@web3modal/ethereum/2.0.0-beta.6_ethers@5.7.2:
-    resolution: {integrity: sha512-jIk0mfINvgk0vteC14Z5v1Wf8stOTKLCRkoxTs+WgfYItcTnaKeUP05NXEpoTO1J1eOUVCW8VZ4K446VFDP20A==}
+  /@web3modal/ethereum/2.2.0_ethers@5.7.2:
+    resolution: {integrity: sha512-/xARXiIyKz9O9plCwNUAoE70gT8r5x6dnJ3cslAC3PW+mUwI3wKVIBuT1garO7BfKK/rnDwDyAeJ+OIbxTT3mw==}
     peerDependencies:
-      '@wagmi/core': '>=0.7'
+      '@wagmi/core': '>=0.10'
       ethers: '>=5.7'
     dependencies:
-      '@coinbase/wallet-sdk': 3.6.0
-      '@walletconnect/ethereum-provider': 1.8.0
       ethers: 5.7.2
-    transitivePeerDependencies:
-      - '@babel/core'
-      - bufferutil
-      - debug
-      - encoding
-      - react-native
-      - supports-color
-      - utf-8-validate
     dev: false
 
-  /@web3modal/react/2.0.0-beta.6_biqbaboplfbrettd7655fr4n2y:
-    resolution: {integrity: sha512-ZxCXmnxJpjNCejBpzmNTHtHGmEW5NLKcWmu3E+Yh9OPFEJLFmMCKjWddF7b95IYs4uYTT+XXAW/c1V1LmekfvA==}
+  /@web3modal/react/2.2.0_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-KJkilvhALgclBAvxVy/+80mceFcNd0KB/dg+DdGVgFut4RwzTrrAfAKldUZMdf0qcR3qxbsposy03CzyaKSSfg==}
     peerDependencies:
       react: '>=17'
       react-dom: '>=17'
     dependencies:
-      '@web3modal/core': 2.0.0-beta.6_react@18.2.0
-      '@web3modal/ui': 2.0.0-beta.6_react@18.2.0
+      '@web3modal/core': 2.2.0_react@18.2.0
+      '@web3modal/ui': 2.2.0_react@18.2.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-    transitivePeerDependencies:
-      - '@babel/helper-module-imports'
-      - '@babel/types'
-      - aslemammad-vite-plugin-macro
-      - babel-plugin-macros
-      - vite
     dev: false
 
-  /@web3modal/react/2.0.0-beta.6_vrbfpf7l3dmha57kzmbjd4uuiq:
-    resolution: {integrity: sha512-ZxCXmnxJpjNCejBpzmNTHtHGmEW5NLKcWmu3E+Yh9OPFEJLFmMCKjWddF7b95IYs4uYTT+XXAW/c1V1LmekfvA==}
-    peerDependencies:
-      react: '>=17'
-      react-dom: '>=17'
+  /@web3modal/standalone/2.2.0_react@18.2.0:
+    resolution: {integrity: sha512-cLFW4VamSJ7L4sM5OGmr1SHK3FgyLUMEaacvHsCA3XSvUF0LxbMC+N4uBsONrW4c0JyIjTdeii1GqG4B3jwn7Q==}
     dependencies:
-      '@web3modal/core': 2.0.0-beta.6_react@18.2.0+vite@3.2.4
-      '@web3modal/ui': 2.0.0-beta.6_react@18.2.0+vite@3.2.4
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
-    transitivePeerDependencies:
-      - '@babel/helper-module-imports'
-      - '@babel/types'
-      - aslemammad-vite-plugin-macro
-      - babel-plugin-macros
-      - vite
-    dev: false
-
-  /@web3modal/standalone/2.0.0_react@18.2.0:
-    resolution: {integrity: sha512-/YcAWgnVtTFeVFrHlhYemS1NU9ds9nbMuV1njjbS9+yDirOXfUenPORi6X1AGs5pUrDnR4IwDgQzdd5wqg6kZw==}
-    dependencies:
-      '@web3modal/core': 2.0.0_react@18.2.0
-      '@web3modal/ui': 2.0.0_react@18.2.0
+      '@web3modal/core': 2.2.0_react@18.2.0
+      '@web3modal/ui': 2.2.0_react@18.2.0
     transitivePeerDependencies:
       - react
     dev: false
 
-  /@web3modal/ui/2.0.0-beta.6_react@18.2.0:
-    resolution: {integrity: sha512-jmt8isnqg0NQ6Heq1nP5bfZoMk5EWqBe7BtWM9auZPdX0p5ZYFwTCfq2Cl15n9rAmpocUzmEH3cg5Hb3avJzdQ==}
+  /@web3modal/ui/2.2.0_react@18.2.0:
+    resolution: {integrity: sha512-jcV5C9AuMdsFdf6Ljsr0v2lInu8FJJyXcZPaMHkgYNIczzgMEpDE+UOA7hLnyCTUxM9R0AgRcgfTyMWb9H8Ssw==}
     dependencies:
-      '@web3modal/core': 2.0.0-beta.6_react@18.2.0
-      lit: 2.4.1
-      motion: 10.14.3
-      qrcode: 1.5.1
-    transitivePeerDependencies:
-      - '@babel/helper-module-imports'
-      - '@babel/types'
-      - aslemammad-vite-plugin-macro
-      - babel-plugin-macros
-      - react
-      - vite
-    dev: false
-
-  /@web3modal/ui/2.0.0-beta.6_react@18.2.0+vite@3.2.4:
-    resolution: {integrity: sha512-jmt8isnqg0NQ6Heq1nP5bfZoMk5EWqBe7BtWM9auZPdX0p5ZYFwTCfq2Cl15n9rAmpocUzmEH3cg5Hb3avJzdQ==}
-    dependencies:
-      '@web3modal/core': 2.0.0-beta.6_react@18.2.0+vite@3.2.4
-      lit: 2.4.1
-      motion: 10.14.3
-      qrcode: 1.5.1
-    transitivePeerDependencies:
-      - '@babel/helper-module-imports'
-      - '@babel/types'
-      - aslemammad-vite-plugin-macro
-      - babel-plugin-macros
-      - react
-      - vite
-    dev: false
-
-  /@web3modal/ui/2.0.0_react@18.2.0:
-    resolution: {integrity: sha512-kNSXD/YI+Sl92hxMzsjkRWUj8H+CyV89WDS0Ywy2YV9HxVzC6MzntnsYZ4rti5//IzeDlxPhTKKaiBWE68Gwzw==}
-    dependencies:
-      '@web3modal/core': 2.0.0_react@18.2.0
+      '@web3modal/core': 2.2.0_react@18.2.0
       lit: 2.6.1
       motion: 10.15.5
       qrcode: 1.5.1
@@ -4241,7 +4692,7 @@ packages:
   /concat-map/0.0.1:
     resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
 
-  /connectkit/1.1.1_li4huv3xlw7e2ejfg4w23au2re:
+  /connectkit/1.1.1_fz36zj7lqr4mpddduwobg5rhxi:
     resolution: {integrity: sha512-aQ6DHuKBMQeed0TJqlb8UJHW4K9jim/CCKBBhSwz6xLhR73tMRxP9nIyKVr/RaC+GYt/TyXBUiKBo0G96cJO6Q==}
     engines: {node: '>=12.4'}
     peerDependencies:
@@ -4261,7 +4712,7 @@ packages:
       react-use-measure: 2.1.1_biqbaboplfbrettd7655fr4n2y
       resize-observer-polyfill: 1.5.1
       styled-components: 5.3.6_biqbaboplfbrettd7655fr4n2y
-      wagmi: 0.11.0_q3rmnbwwunsufccbu3lnf7uwce
+      wagmi: 0.11.7_q3rmnbwwunsufccbu3lnf7uwce
     transitivePeerDependencies:
       - react-is
     dev: false
@@ -4775,6 +5226,7 @@ packages:
     cpu: [x64]
     os: [android]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-android-64/0.15.13:
@@ -4792,6 +5244,7 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-android-arm64/0.15.13:
@@ -4809,6 +5262,7 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-darwin-64/0.15.13:
@@ -4826,6 +5280,7 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-darwin-arm64/0.15.13:
@@ -4843,6 +5298,7 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-freebsd-64/0.15.13:
@@ -4860,6 +5316,7 @@ packages:
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-freebsd-arm64/0.15.13:
@@ -4877,6 +5334,7 @@ packages:
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-32/0.15.13:
@@ -4894,6 +5352,7 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-64/0.15.13:
@@ -4911,6 +5370,7 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-arm/0.15.13:
@@ -4928,6 +5388,7 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-arm64/0.15.13:
@@ -4945,6 +5406,7 @@ packages:
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-mips64le/0.15.13:
@@ -4962,6 +5424,7 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-ppc64le/0.15.13:
@@ -4979,6 +5442,7 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-riscv64/0.15.13:
@@ -4996,6 +5460,7 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-linux-s390x/0.15.13:
@@ -5013,6 +5478,7 @@ packages:
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-netbsd-64/0.15.13:
@@ -5030,6 +5496,7 @@ packages:
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-openbsd-64/0.15.13:
@@ -5047,6 +5514,7 @@ packages:
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-sunos-64/0.15.13:
@@ -5064,6 +5532,7 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-windows-32/0.15.13:
@@ -5081,6 +5550,7 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-windows-64/0.15.13:
@@ -5098,6 +5568,7 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /esbuild-windows-arm64/0.15.13:
@@ -5137,6 +5608,7 @@ packages:
       esbuild-windows-32: 0.15.12
       esbuild-windows-64: 0.15.12
       esbuild-windows-arm64: 0.15.12
+    dev: true
 
   /esbuild/0.15.13:
     resolution: {integrity: sha512-Cu3SC84oyzzhrK/YyN4iEVy2jZu5t2fz66HEOShHURcjSkOSAVL8C/gfUT+lDJxkVHpg8GZ10DD0rMHRPqMFaQ==}
@@ -6770,14 +7242,6 @@ packages:
       '@types/trusted-types': 2.0.2
     dev: false
 
-  /lit/2.4.1:
-    resolution: {integrity: sha512-qohSgLiyN1cFnJG26dIiY03S4F49857A0AHQfnS0zYtnUVnD2MFvx+UT52rtXsIuNFQrnUupX+zyGSATlk1f/A==}
-    dependencies:
-      '@lit/reactive-element': 1.6.1
-      lit-element: 3.2.2
-      lit-html: 2.6.1
-    dev: false
-
   /lit/2.6.1:
     resolution: {integrity: sha512-DT87LD64f8acR7uVp7kZfhLRrHkfC/N4BVzAtnw9Yg8087mbBJ//qedwdwX0kzDbxgPccWRW6mFwGbRQIxy0pw==}
     dependencies:
@@ -7057,17 +7521,6 @@ packages:
       yargs: 16.2.0
       yargs-parser: 20.2.4
       yargs-unparser: 2.0.0
-    dev: false
-
-  /motion/10.14.3:
-    resolution: {integrity: sha512-xBbgYho8nPiR2OZOrfJTbJpiiQl0F2PZF6H5ItAeIPJEfA/x0ZwxpFC/gbsKfUv3CFUVAoxCRkTDCJjiZ48dxw==}
-    dependencies:
-      '@motionone/animation': 10.15.1
-      '@motionone/dom': 10.15.5
-      '@motionone/svelte': 10.15.5
-      '@motionone/types': 10.15.1
-      '@motionone/utils': 10.15.1
-      '@motionone/vue': 10.15.5
     dev: false
 
   /motion/10.15.5:
@@ -7676,9 +8129,14 @@ packages:
       nanoid: 3.3.4
       picocolors: 1.0.0
       source-map-js: 1.0.2
+    dev: true
 
   /preact/10.11.3:
     resolution: {integrity: sha512-eY93IVpod/zG3uMF22Unl8h9KkrcKIRs2EGar8hwLZZDU1lkjph303V9HZBwufh2s736U6VXuhD109LYqPoffg==}
+    dev: false
+
+  /preact/10.13.1:
+    resolution: {integrity: sha512-KyoXVDU5OqTpG9LXlB3+y639JAGzl8JSBXLn1J9HTSB3gbKcuInga7bZnXLlxmK94ntTs1EFeZp0lrja2AuBYQ==}
     dev: false
 
   /preact/10.4.1:
@@ -7743,10 +8201,6 @@ packages:
       object-assign: 4.1.1
       react-is: 16.13.1
     dev: true
-
-  /proxy-compare/2.3.0:
-    resolution: {integrity: sha512-c3L2CcAi7f7pvlD0D7xsF+2CQIW8C3HaYx2Pfgq8eA4HAl3GAH6/dVYsyBbYF/0XJs2ziGLrzmz5fmzPm6A0pQ==}
-    dev: false
 
   /proxy-compare/2.4.0:
     resolution: {integrity: sha512-FD8KmQUQD6Mfpd0hywCOzcon/dbkFP8XBd9F1ycbKtvVsfv6TsFUKJ2eC0Iz2y+KzlkdT1Z8SY6ZSgm07zOyqg==}
@@ -8133,6 +8587,7 @@ packages:
     hasBin: true
     optionalDependencies:
       fsevents: 2.3.2
+    dev: true
 
   /rpc-websockets/7.5.0:
     resolution: {integrity: sha512-9tIRi1uZGy7YmDjErf1Ax3wtqdSSLIlnmL5OtOzgd5eqPKbsPpwDP5whUDO2LQay3Xp0CcHlcNSGzacNRluBaQ==}
@@ -9072,65 +9527,6 @@ packages:
       builtins: 5.0.1
     dev: false
 
-  /valtio/1.7.6_react@18.2.0:
-    resolution: {integrity: sha512-zsGrCCYOIpy8egQxftduFyJusF/BMu3CganhHKUOE/I6t6V6yA1MDfZZkrYoWYCGkC3rSBYcIHEEsoYQM9lV2w==}
-    engines: {node: '>=12.7.0'}
-    peerDependencies:
-      '@babel/helper-module-imports': '>=7.12'
-      '@babel/types': '>=7.13'
-      aslemammad-vite-plugin-macro: '>=1.0.0-alpha.1'
-      babel-plugin-macros: '>=3.0'
-      react: '>=16.8'
-      vite: '>=2.8.6'
-    peerDependenciesMeta:
-      '@babel/helper-module-imports':
-        optional: true
-      '@babel/types':
-        optional: true
-      aslemammad-vite-plugin-macro:
-        optional: true
-      babel-plugin-macros:
-        optional: true
-      react:
-        optional: true
-      vite:
-        optional: true
-    dependencies:
-      proxy-compare: 2.3.0
-      react: 18.2.0
-      use-sync-external-store: 1.2.0_react@18.2.0
-    dev: false
-
-  /valtio/1.7.6_react@18.2.0+vite@3.2.4:
-    resolution: {integrity: sha512-zsGrCCYOIpy8egQxftduFyJusF/BMu3CganhHKUOE/I6t6V6yA1MDfZZkrYoWYCGkC3rSBYcIHEEsoYQM9lV2w==}
-    engines: {node: '>=12.7.0'}
-    peerDependencies:
-      '@babel/helper-module-imports': '>=7.12'
-      '@babel/types': '>=7.13'
-      aslemammad-vite-plugin-macro: '>=1.0.0-alpha.1'
-      babel-plugin-macros: '>=3.0'
-      react: '>=16.8'
-      vite: '>=2.8.6'
-    peerDependenciesMeta:
-      '@babel/helper-module-imports':
-        optional: true
-      '@babel/types':
-        optional: true
-      aslemammad-vite-plugin-macro:
-        optional: true
-      babel-plugin-macros:
-        optional: true
-      react:
-        optional: true
-      vite:
-        optional: true
-    dependencies:
-      proxy-compare: 2.3.0
-      react: 18.2.0
-      use-sync-external-store: 1.2.0_react@18.2.0
-      vite: 3.2.4
-    dev: false
-
   /valtio/1.9.0_react@18.2.0:
     resolution: {integrity: sha512-mQLFsAlKbYascZygFQh6lXuDjU5WHLoeZ8He4HqMnWfasM96V6rDbeFkw1XeG54xycmDonr/Jb4xgviHtuySrA==}
     engines: {node: '>=12.20.0'}
@@ -9176,11 +9572,12 @@ packages:
       rollup: 2.79.1
     optionalDependencies:
       fsevents: 2.3.2
+    dev: true
 
-  /wagmi/0.11.0_5fkdkfy2bkgsnhvxgn477z7iae:
-    resolution: {integrity: sha512-7yvZAe7ba6mwI8hr0wkkdjC/JebsGLTnz8kOsx6e/9/ka32Axg1OVsGAWin7BV2vQazZxn9tNNMN/0cMEZe1pg==}
+  /wagmi/0.11.7_5fkdkfy2bkgsnhvxgn477z7iae:
+    resolution: {integrity: sha512-IiB1TxTVn+xvjju3ZNQfiwfiB6EZj1h3CO7Zt8q0PEDRN76jqniaeOV7QAnfBgtbqmVh2co4Miaz1rRtvVPMTQ==}
     peerDependencies:
-      ethers: '>=5.5.1'
+      ethers: '>=5.5.1 <6'
       react: '>=17.0.0'
       typescript: '>=4.9.4'
     peerDependenciesMeta:
@@ -9190,7 +9587,7 @@ packages:
       '@tanstack/query-sync-storage-persister': 4.15.1
       '@tanstack/react-query': 4.16.1_biqbaboplfbrettd7655fr4n2y
       '@tanstack/react-query-persist-client': 4.16.1_fsy4krnncv4idvr4txy3aqiuqm
-      '@wagmi/core': 0.9.0_2zmba3zh2lo2ye5dzgeckiacfa
+      '@wagmi/core': 0.9.7_2zmba3zh2lo2ye5dzgeckiacfa
       abitype: 0.3.0_typescript@4.9.4
       ethers: 5.7.2
       react: 18.2.0
@@ -9215,10 +9612,10 @@ packages:
       - zod
     dev: false
 
-  /wagmi/0.11.0_q3rmnbwwunsufccbu3lnf7uwce:
-    resolution: {integrity: sha512-7yvZAe7ba6mwI8hr0wkkdjC/JebsGLTnz8kOsx6e/9/ka32Axg1OVsGAWin7BV2vQazZxn9tNNMN/0cMEZe1pg==}
+  /wagmi/0.11.7_q3rmnbwwunsufccbu3lnf7uwce:
+    resolution: {integrity: sha512-IiB1TxTVn+xvjju3ZNQfiwfiB6EZj1h3CO7Zt8q0PEDRN76jqniaeOV7QAnfBgtbqmVh2co4Miaz1rRtvVPMTQ==}
     peerDependencies:
-      ethers: '>=5.5.1'
+      ethers: '>=5.5.1 <6'
       react: '>=17.0.0'
       typescript: '>=4.9.4'
     peerDependenciesMeta:
@@ -9228,7 +9625,83 @@ packages:
       '@tanstack/query-sync-storage-persister': 4.15.1
       '@tanstack/react-query': 4.16.1_biqbaboplfbrettd7655fr4n2y
       '@tanstack/react-query-persist-client': 4.16.1_fsy4krnncv4idvr4txy3aqiuqm
-      '@wagmi/core': 0.9.0_fz5ualg3bc2nr2e6kzfsjxcmya
+      '@wagmi/core': 0.9.7_fz5ualg3bc2nr2e6kzfsjxcmya
+      abitype: 0.3.0_typescript@4.9.4
+      ethers: 5.7.2
+      react: 18.2.0
+      typescript: 4.9.4
+      use-sync-external-store: 1.2.0_react@18.2.0
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@react-native-async-storage/async-storage'
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@tanstack/query-core'
+      - '@types/node'
+      - bufferutil
+      - debug
+      - encoding
+      - immer
+      - lokijs
+      - react-dom
+      - react-native
+      - supports-color
+      - utf-8-validate
+      - zod
+    dev: false
+
+  /wagmi/0.12.1_5fkdkfy2bkgsnhvxgn477z7iae:
+    resolution: {integrity: sha512-O3X2D5dm3LBesuVSG8qdwSEIulDUn9pouSW/bOn/xdbKR6Q/GouphbiqOyoTn+a1urKlmDI7nq9EU6UeY8Hd3w==}
+    peerDependencies:
+      ethers: '>=5.5.1 <6'
+      react: '>=17.0.0'
+      typescript: '>=4.9.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@tanstack/query-sync-storage-persister': 4.15.1
+      '@tanstack/react-query': 4.16.1_biqbaboplfbrettd7655fr4n2y
+      '@tanstack/react-query-persist-client': 4.16.1_fsy4krnncv4idvr4txy3aqiuqm
+      '@wagmi/core': 0.10.1_2zmba3zh2lo2ye5dzgeckiacfa
+      abitype: 0.3.0_typescript@4.9.4
+      ethers: 5.7.2
+      react: 18.2.0
+      typescript: 4.9.4
+      use-sync-external-store: 1.2.0_react@18.2.0
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@react-native-async-storage/async-storage'
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@tanstack/query-core'
+      - '@types/node'
+      - bufferutil
+      - debug
+      - encoding
+      - immer
+      - lokijs
+      - react-dom
+      - react-native
+      - supports-color
+      - utf-8-validate
+      - zod
+    dev: false
+
+  /wagmi/0.12.1_q3rmnbwwunsufccbu3lnf7uwce:
+    resolution: {integrity: sha512-O3X2D5dm3LBesuVSG8qdwSEIulDUn9pouSW/bOn/xdbKR6Q/GouphbiqOyoTn+a1urKlmDI7nq9EU6UeY8Hd3w==}
+    peerDependencies:
+      ethers: '>=5.5.1 <6'
+      react: '>=17.0.0'
+      typescript: '>=4.9.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@tanstack/query-sync-storage-persister': 4.15.1
+      '@tanstack/react-query': 4.16.1_biqbaboplfbrettd7655fr4n2y
+      '@tanstack/react-query-persist-client': 4.16.1_fsy4krnncv4idvr4txy3aqiuqm
+      '@wagmi/core': 0.10.1_fz5ualg3bc2nr2e6kzfsjxcmya
       abitype: 0.3.0_typescript@4.9.4
       ethers: 5.7.2
       react: 18.2.0

--- a/templates/next/cli-abi/package.json
+++ b/templates/next/cli-abi/package.json
@@ -15,7 +15,7 @@
     "next": "^13.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "wagmi": "~0.11.0"
+    "wagmi": "~0.12.0"
   },
   "devDependencies": {
     "@types/node": "^17.0.31",

--- a/templates/next/cli-abi/src/wagmi.ts
+++ b/templates/next/cli-abi/src/wagmi.ts
@@ -3,7 +3,7 @@ import { goerli, mainnet } from 'wagmi/chains'
 import { CoinbaseWalletConnector } from 'wagmi/connectors/coinbaseWallet'
 import { InjectedConnector } from 'wagmi/connectors/injected'
 import { MetaMaskConnector } from 'wagmi/connectors/metaMask'
-import { WalletConnectConnector } from 'wagmi/connectors/walletConnect'
+import { WalletConnectLegacyConnector } from 'wagmi/connectors/walletConnectLegacy'
 
 import { publicProvider } from 'wagmi/providers/public'
 
@@ -22,7 +22,7 @@ export const client = createClient({
         appName: 'wagmi',
       },
     }),
-    new WalletConnectConnector({
+    new WalletConnectLegacyConnector({
       chains,
       options: {
         qrcode: true,

--- a/templates/next/cli-erc/package.json
+++ b/templates/next/cli-erc/package.json
@@ -15,7 +15,7 @@
     "next": "^13.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "wagmi": "~0.11.0"
+    "wagmi": "~0.12.0"
   },
   "devDependencies": {
     "@types/node": "^17.0.31",

--- a/templates/next/cli-erc/src/wagmi.ts
+++ b/templates/next/cli-erc/src/wagmi.ts
@@ -3,7 +3,7 @@ import { goerli, mainnet } from 'wagmi/chains'
 import { CoinbaseWalletConnector } from 'wagmi/connectors/coinbaseWallet'
 import { InjectedConnector } from 'wagmi/connectors/injected'
 import { MetaMaskConnector } from 'wagmi/connectors/metaMask'
-import { WalletConnectConnector } from 'wagmi/connectors/walletConnect'
+import { WalletConnectLegacyConnector } from 'wagmi/connectors/walletConnectLegacy'
 
 import { publicProvider } from 'wagmi/providers/public'
 
@@ -22,7 +22,7 @@ export const client = createClient({
         appName: 'wagmi',
       },
     }),
-    new WalletConnectConnector({
+    new WalletConnectLegacyConnector({
       chains,
       options: {
         qrcode: true,

--- a/templates/next/cli-etherscan/package.json
+++ b/templates/next/cli-etherscan/package.json
@@ -15,7 +15,7 @@
     "next": "^13.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "wagmi": "~0.11.0"
+    "wagmi": "~0.12.0"
   },
   "devDependencies": {
     "@types/node": "^17.0.31",

--- a/templates/next/cli-etherscan/src/wagmi.ts
+++ b/templates/next/cli-etherscan/src/wagmi.ts
@@ -3,7 +3,7 @@ import { goerli, mainnet } from 'wagmi/chains'
 import { CoinbaseWalletConnector } from 'wagmi/connectors/coinbaseWallet'
 import { InjectedConnector } from 'wagmi/connectors/injected'
 import { MetaMaskConnector } from 'wagmi/connectors/metaMask'
-import { WalletConnectConnector } from 'wagmi/connectors/walletConnect'
+import { WalletConnectLegacyConnector } from 'wagmi/connectors/walletConnectLegacy'
 
 import { publicProvider } from 'wagmi/providers/public'
 
@@ -22,7 +22,7 @@ export const client = createClient({
         appName: 'wagmi',
       },
     }),
-    new WalletConnectConnector({
+    new WalletConnectLegacyConnector({
       chains,
       options: {
         qrcode: true,

--- a/templates/next/cli-foundry/package.json
+++ b/templates/next/cli-foundry/package.json
@@ -19,7 +19,7 @@
     "next": "^13.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "wagmi": "~0.11.0"
+    "wagmi": "~0.12.0"
   },
   "devDependencies": {
     "@types/node": "^17.0.31",

--- a/templates/next/cli-foundry/src/wagmi.ts
+++ b/templates/next/cli-foundry/src/wagmi.ts
@@ -3,7 +3,7 @@ import { foundry, goerli, mainnet } from 'wagmi/chains'
 import { CoinbaseWalletConnector } from 'wagmi/connectors/coinbaseWallet'
 import { InjectedConnector } from 'wagmi/connectors/injected'
 import { MetaMaskConnector } from 'wagmi/connectors/metaMask'
-import { WalletConnectConnector } from 'wagmi/connectors/walletConnect'
+import { WalletConnectLegacyConnector } from 'wagmi/connectors/walletConnectLegacy'
 
 import { publicProvider } from 'wagmi/providers/public'
 
@@ -25,7 +25,7 @@ export const client = createClient({
         appName: 'wagmi',
       },
     }),
-    new WalletConnectConnector({
+    new WalletConnectLegacyConnector({
       chains,
       options: {
         qrcode: true,

--- a/templates/next/default/package.json
+++ b/templates/next/default/package.json
@@ -13,7 +13,7 @@
     "next": "^13.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "wagmi": "~0.11.0"
+    "wagmi": "~0.12.0"
   },
   "devDependencies": {
     "@types/node": "^17.0.31",

--- a/templates/next/default/src/wagmi.ts
+++ b/templates/next/default/src/wagmi.ts
@@ -3,7 +3,7 @@ import { goerli, mainnet } from 'wagmi/chains'
 import { CoinbaseWalletConnector } from 'wagmi/connectors/coinbaseWallet'
 import { InjectedConnector } from 'wagmi/connectors/injected'
 import { MetaMaskConnector } from 'wagmi/connectors/metaMask'
-import { WalletConnectConnector } from 'wagmi/connectors/walletConnect'
+import { WalletConnectLegacyConnector } from 'wagmi/connectors/walletConnectLegacy'
 
 import { publicProvider } from 'wagmi/providers/public'
 
@@ -22,7 +22,7 @@ export const client = createClient({
         appName: 'wagmi',
       },
     }),
-    new WalletConnectConnector({
+    new WalletConnectLegacyConnector({
       chains,
       options: {
         qrcode: true,

--- a/templates/next/rainbowkit/package.json
+++ b/templates/next/rainbowkit/package.json
@@ -9,12 +9,12 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@rainbow-me/rainbowkit": "^0.8.1",
+    "@rainbow-me/rainbowkit": "~0.12.1",
     "ethers": "^5.7.0",
     "next": "^13.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "wagmi": "~0.11.0"
+    "wagmi": "~0.12.0"
   },
   "devDependencies": {
     "@types/node": "^17.0.31",

--- a/templates/next/web3modal/package.json
+++ b/templates/next/web3modal/package.json
@@ -9,13 +9,13 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@web3modal/ethereum": "2.0.0-beta.6",
-    "@web3modal/react": "2.0.0-beta.6",
+    "@web3modal/ethereum": "2.2.0",
+    "@web3modal/react": "2.2.0",
     "ethers": "^5.7.2",
     "next": "^13.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "wagmi": "~0.11.0"
+    "wagmi": "~0.12.0"
   },
   "devDependencies": {
     "@types/node": "^17.0.31",

--- a/templates/next/web3modal/src/wagmi.ts
+++ b/templates/next/web3modal/src/wagmi.ts
@@ -1,4 +1,4 @@
-import { modalConnectors, walletConnectProvider } from '@web3modal/ethereum'
+import { w3mConnectors, w3mProvider } from '@web3modal/ethereum'
 import { configureChains, createClient } from 'wagmi'
 import { goerli, mainnet } from 'wagmi/chains'
 
@@ -6,12 +6,16 @@ export const walletConnectProjectId = '<WALLET_CONNECT_PROJECT_ID>'
 
 const { chains, provider, webSocketProvider } = configureChains(
   [mainnet, ...(process.env.NODE_ENV === 'development' ? [goerli] : [])],
-  [walletConnectProvider({ projectId: walletConnectProjectId })],
+  [w3mProvider({ projectId: walletConnectProjectId })],
 )
 
 export const client = createClient({
   autoConnect: true,
-  connectors: modalConnectors({ appName: 'My wagmi + Web3Modal App', chains }),
+  connectors: w3mConnectors({
+    chains,
+    projectId: walletConnectProjectId,
+    version: 1,
+  }),
   provider,
   webSocketProvider,
 })

--- a/templates/vite-react/cli-abi/package.json
+++ b/templates/vite-react/cli-abi/package.json
@@ -16,7 +16,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "util": "^0.12.4",
-    "wagmi": "~0.11.0"
+    "wagmi": "~0.12.0"
   },
   "devDependencies": {
     "@types/react": "^18.0.9",

--- a/templates/vite-react/cli-abi/src/wagmi.ts
+++ b/templates/vite-react/cli-abi/src/wagmi.ts
@@ -3,7 +3,7 @@ import { goerli, mainnet } from 'wagmi/chains'
 import { CoinbaseWalletConnector } from 'wagmi/connectors/coinbaseWallet'
 import { InjectedConnector } from 'wagmi/connectors/injected'
 import { MetaMaskConnector } from 'wagmi/connectors/metaMask'
-import { WalletConnectConnector } from 'wagmi/connectors/walletConnect'
+import { WalletConnectLegacyConnector } from 'wagmi/connectors/walletConnectLegacy'
 import { publicProvider } from 'wagmi/providers/public'
 
 const { chains, provider, webSocketProvider } = configureChains(
@@ -21,7 +21,7 @@ export const client = createClient({
         appName: 'wagmi',
       },
     }),
-    new WalletConnectConnector({
+    new WalletConnectLegacyConnector({
       chains,
       options: {
         qrcode: true,

--- a/templates/vite-react/cli-erc/package.json
+++ b/templates/vite-react/cli-erc/package.json
@@ -16,7 +16,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "util": "^0.12.4",
-    "wagmi": "~0.11.0"
+    "wagmi": "~0.12.0"
   },
   "devDependencies": {
     "@types/react": "^18.0.9",

--- a/templates/vite-react/cli-erc/src/wagmi.ts
+++ b/templates/vite-react/cli-erc/src/wagmi.ts
@@ -3,7 +3,7 @@ import { goerli, mainnet } from 'wagmi/chains'
 import { CoinbaseWalletConnector } from 'wagmi/connectors/coinbaseWallet'
 import { InjectedConnector } from 'wagmi/connectors/injected'
 import { MetaMaskConnector } from 'wagmi/connectors/metaMask'
-import { WalletConnectConnector } from 'wagmi/connectors/walletConnect'
+import { WalletConnectLegacyConnector } from 'wagmi/connectors/walletConnectLegacy'
 import { publicProvider } from 'wagmi/providers/public'
 
 const { chains, provider, webSocketProvider } = configureChains(
@@ -21,7 +21,7 @@ export const client = createClient({
         appName: 'wagmi',
       },
     }),
-    new WalletConnectConnector({
+    new WalletConnectLegacyConnector({
       chains,
       options: {
         qrcode: true,

--- a/templates/vite-react/cli-etherscan/package.json
+++ b/templates/vite-react/cli-etherscan/package.json
@@ -16,7 +16,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "util": "^0.12.4",
-    "wagmi": "~0.11.0"
+    "wagmi": "~0.12.0"
   },
   "devDependencies": {
     "@types/react": "^18.0.9",

--- a/templates/vite-react/cli-etherscan/src/wagmi.ts
+++ b/templates/vite-react/cli-etherscan/src/wagmi.ts
@@ -3,7 +3,7 @@ import { goerli, mainnet } from 'wagmi/chains'
 import { CoinbaseWalletConnector } from 'wagmi/connectors/coinbaseWallet'
 import { InjectedConnector } from 'wagmi/connectors/injected'
 import { MetaMaskConnector } from 'wagmi/connectors/metaMask'
-import { WalletConnectConnector } from 'wagmi/connectors/walletConnect'
+import { WalletConnectLegacyConnector } from 'wagmi/connectors/walletConnectLegacy'
 import { publicProvider } from 'wagmi/providers/public'
 
 const { chains, provider, webSocketProvider } = configureChains(
@@ -21,7 +21,7 @@ export const client = createClient({
         appName: 'wagmi',
       },
     }),
-    new WalletConnectConnector({
+    new WalletConnectLegacyConnector({
       chains,
       options: {
         qrcode: true,

--- a/templates/vite-react/cli-foundry/package.json
+++ b/templates/vite-react/cli-foundry/package.json
@@ -20,7 +20,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "util": "^0.12.4",
-    "wagmi": "~0.11.0"
+    "wagmi": "~0.12.0"
   },
   "devDependencies": {
     "@types/react": "^18.0.9",

--- a/templates/vite-react/cli-foundry/src/wagmi.ts
+++ b/templates/vite-react/cli-foundry/src/wagmi.ts
@@ -3,7 +3,7 @@ import { foundry, goerli, mainnet } from 'wagmi/chains'
 import { CoinbaseWalletConnector } from 'wagmi/connectors/coinbaseWallet'
 import { InjectedConnector } from 'wagmi/connectors/injected'
 import { MetaMaskConnector } from 'wagmi/connectors/metaMask'
-import { WalletConnectConnector } from 'wagmi/connectors/walletConnect'
+import { WalletConnectLegacyConnector } from 'wagmi/connectors/walletConnectLegacy'
 import { publicProvider } from 'wagmi/providers/public'
 
 const { chains, provider, webSocketProvider } = configureChains(
@@ -24,7 +24,7 @@ export const client = createClient({
         appName: 'wagmi',
       },
     }),
-    new WalletConnectConnector({
+    new WalletConnectLegacyConnector({
       chains,
       options: {
         qrcode: true,

--- a/templates/vite-react/default/package.json
+++ b/templates/vite-react/default/package.json
@@ -14,7 +14,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "util": "^0.12.4",
-    "wagmi": "~0.11.0"
+    "wagmi": "~0.12.0"
   },
   "devDependencies": {
     "@types/react": "^18.0.9",

--- a/templates/vite-react/default/src/wagmi.ts
+++ b/templates/vite-react/default/src/wagmi.ts
@@ -3,7 +3,7 @@ import { goerli, mainnet } from 'wagmi/chains'
 import { CoinbaseWalletConnector } from 'wagmi/connectors/coinbaseWallet'
 import { InjectedConnector } from 'wagmi/connectors/injected'
 import { MetaMaskConnector } from 'wagmi/connectors/metaMask'
-import { WalletConnectConnector } from 'wagmi/connectors/walletConnect'
+import { WalletConnectLegacyConnector } from 'wagmi/connectors/walletConnectLegacy'
 import { publicProvider } from 'wagmi/providers/public'
 
 const { chains, provider, webSocketProvider } = configureChains(
@@ -21,7 +21,7 @@ export const client = createClient({
         appName: 'wagmi',
       },
     }),
-    new WalletConnectConnector({
+    new WalletConnectLegacyConnector({
       chains,
       options: {
         qrcode: true,

--- a/templates/vite-react/rainbowkit/package.json
+++ b/templates/vite-react/rainbowkit/package.json
@@ -8,14 +8,14 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@rainbow-me/rainbowkit": "^0.8.1",
+    "@rainbow-me/rainbowkit": "~0.12.1",
     "buffer": "^6.0.3",
     "ethers": "^5.7.2",
     "process": "^0.11.10",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "util": "^0.12.4",
-    "wagmi": "~0.11.0"
+    "wagmi": "~0.12.0"
   },
   "devDependencies": {
     "@types/react": "^18.0.9",

--- a/templates/vite-react/web3modal/package.json
+++ b/templates/vite-react/web3modal/package.json
@@ -8,15 +8,15 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@web3modal/ethereum": "2.0.0-beta.6",
-    "@web3modal/react": "2.0.0-beta.6",
+    "@web3modal/ethereum": "2.2.0",
+    "@web3modal/react": "2.2.0",
     "buffer": "^6.0.3",
     "ethers": "^5.7.2",
     "process": "^0.11.10",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "util": "^0.12.4",
-    "wagmi": "~0.11.0"
+    "wagmi": "~0.12.0"
   },
   "devDependencies": {
     "@types/react": "^18.0.9",

--- a/templates/vite-react/web3modal/src/wagmi.ts
+++ b/templates/vite-react/web3modal/src/wagmi.ts
@@ -2,7 +2,7 @@ import { w3mConnectors, w3mProvider } from '@web3modal/ethereum'
 import { configureChains, createClient } from 'wagmi'
 import { goerli, mainnet } from 'wagmi/chains'
 
-export const walletConnectProjectId = 'ba7804e457fbb5f1375cbdc14e679617'
+export const walletConnectProjectId = '<WALLET_CONNECT_PROJECT_ID>'
 
 const { chains, provider, webSocketProvider } = configureChains(
   [mainnet, ...(import.meta.env?.MODE === 'development' ? [goerli] : [])],

--- a/templates/vite-react/web3modal/src/wagmi.ts
+++ b/templates/vite-react/web3modal/src/wagmi.ts
@@ -1,4 +1,4 @@
-import { modalConnectors, walletConnectProvider } from '@web3modal/ethereum'
+import { w3mConnectors, w3mProvider } from '@web3modal/ethereum'
 import { configureChains, createClient } from 'wagmi'
 import { goerli, mainnet } from 'wagmi/chains'
 
@@ -6,12 +6,16 @@ export const walletConnectProjectId = 'ba7804e457fbb5f1375cbdc14e679617'
 
 const { chains, provider, webSocketProvider } = configureChains(
   [mainnet, ...(import.meta.env?.MODE === 'development' ? [goerli] : [])],
-  [walletConnectProvider({ projectId: walletConnectProjectId })],
+  [w3mProvider({ projectId: walletConnectProjectId })],
 )
 
 export const client = createClient({
   autoConnect: true,
-  connectors: modalConnectors({ appName: 'My wagmi + Web3Modal App', chains }),
+  connectors: w3mConnectors({
+    chains,
+    projectId: walletConnectProjectId,
+    version: 1,
+  }),
   provider,
   webSocketProvider,
 })


### PR DESCRIPTION
## Description

Updated wagmi to `~0.12.0`.

Templates use `WalletConnectLegacyConnector` out-of-the-box – will create a separate PR for WC v2 support as we will need to make a prompt for WC Project ID (or prompt to select connectors).

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/create/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: jxom.eth
