### PR TITLE
Fix optional walletconnect id prompt

### DIFF
--- a/.changeset/lucky-chicken-cross.md
+++ b/.changeset/lucky-chicken-cross.md
@@ -1,0 +1,5 @@
+---
+'create-wagmi': patch
+---
+
+Fixed optional WalletConnect Cloud Project ID prompt

--- a/src/hooks/common/promptAndInjectProjectId.ts
+++ b/src/hooks/common/promptAndInjectProjectId.ts
@@ -26,7 +26,7 @@ export const promptAndInjectProjectId = ({
           )}\n` + (!required ? `${pico.cyan('⏎ to skip')}\n` : ''),
         type: 'text',
         validate: (id) => {
-          if (!id) return 'Project ID is required.'
+          if (!id && required) return 'Project ID is required.'
           return true
         },
       })


### PR DESCRIPTION
## Description

When selecting the default template, the CLI prompts for an optional "WalletConnect Cloud Project ID". However, if the user chooses to skip this question by pressing 'enter' as suggested by the prompt, they receive a 'Project ID is required' message. This PR rectifies the issue by adding `required` as part of the conditional statement, which will trigger an error message only when the ID is not provided and it is indeed required. The image below illustrates the issue at hand.
<img width="641" alt="image" src="https://github.com/wagmi-dev/create-wagmi/assets/18421017/61501161-5452-4413-abbd-649678bbc242">


## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/create/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
vitormarthendal.eth
