### PR TITLE
Fix bug: Type error: Page "src/app/page.tsx" does not match the required types of a Next.js Page.

### DIFF
--- a/.changeset/great-spoons-juggle.md
+++ b/.changeset/great-spoons-juggle.md
@@ -1,0 +1,5 @@
+---
+'create-wagmi': patch
+---
+
+Fix `Type error: Page "src/app/page.tsx" does not match the required types of a Next.js Page.` on `next build`.

--- a/templates/next/cli-abi/src/app/page.tsx
+++ b/templates/next/cli-abi/src/app/page.tsx
@@ -4,7 +4,7 @@ import { Connected } from '../components/Connected'
 import { MintNFT } from '../components/MintNFT'
 import { NetworkSwitcher } from '../components/NetworkSwitcher'
 
-export function Page() {
+export default function Page() {
   return (
     <>
       <h1>wagmi + Next.js + @wagmi/cli (ABI)</h1>
@@ -21,5 +21,3 @@ export function Page() {
     </>
   )
 }
-
-export default Page

--- a/templates/next/cli-erc/src/app/page.tsx
+++ b/templates/next/cli-erc/src/app/page.tsx
@@ -4,7 +4,7 @@ import { Connected } from '../components/Connected'
 import { ERC20 } from '../components/ERC20'
 import { NetworkSwitcher } from '../components/NetworkSwitcher'
 
-export function Page() {
+export default function Page() {
   return (
     <>
       <h1>wagmi + Next.js + @wagmi/cli (ERC20)</h1>
@@ -21,5 +21,3 @@ export function Page() {
     </>
   )
 }
-
-export default Page

--- a/templates/next/cli-etherscan/src/app/page.tsx
+++ b/templates/next/cli-etherscan/src/app/page.tsx
@@ -4,7 +4,7 @@ import { Connected } from '../components/Connected'
 import { MintNFT } from '../components/MintNFT'
 import { NetworkSwitcher } from '../components/NetworkSwitcher'
 
-export function Page() {
+export default function Page() {
   return (
     <>
       <h1>wagmi + Next.js + @wagmi/cli (Etherscan)</h1>
@@ -21,5 +21,3 @@ export function Page() {
     </>
   )
 }
-
-export default Page

--- a/templates/next/cli-foundry/src/app/page.tsx
+++ b/templates/next/cli-foundry/src/app/page.tsx
@@ -4,7 +4,7 @@ import { Connected } from '../components/Connected'
 import { Counter } from '../components/Counter'
 import { NetworkSwitcher } from '../components/NetworkSwitcher'
 
-export function Page() {
+export default function Page() {
   return (
     <>
       <h1>wagmi + Next.js + Foundry</h1>
@@ -21,5 +21,3 @@ export function Page() {
     </>
   )
 }
-
-export default Page

--- a/templates/next/connectkit/src/app/page.tsx
+++ b/templates/next/connectkit/src/app/page.tsx
@@ -17,7 +17,7 @@ import { WatchPendingTransactions } from '../components/WatchPendingTransactions
 import { WriteContract } from '../components/WriteContract'
 import { WriteContractPrepared } from '../components/WriteContractPrepared'
 
-export function Page() {
+export default function Page() {
   return (
     <>
       <h1>wagmi + ConnectKit + Next.js</h1>
@@ -92,5 +92,3 @@ export function Page() {
     </>
   )
 }
-
-export default Page

--- a/templates/next/rainbowkit/src/app/page.tsx
+++ b/templates/next/rainbowkit/src/app/page.tsx
@@ -17,7 +17,7 @@ import { WatchPendingTransactions } from '../components/WatchPendingTransactions
 import { WriteContract } from '../components/WriteContract'
 import { WriteContractPrepared } from '../components/WriteContractPrepared'
 
-export function Page() {
+export default function Page() {
   return (
     <>
       <h1>wagmi + RainbowKit + Next.js</h1>
@@ -92,5 +92,3 @@ export function Page() {
     </>
   )
 }
-
-export default Page

--- a/templates/next/web3modal/src/app/page.tsx
+++ b/templates/next/web3modal/src/app/page.tsx
@@ -17,7 +17,7 @@ import { Web3Button } from '../components/Web3Button'
 import { WriteContract } from '../components/WriteContract'
 import { WriteContractPrepared } from '../components/WriteContractPrepared'
 
-export function Page() {
+export default function Page() {
   return (
     <>
       <h1>wagmi + Web3Modal + Next.js</h1>
@@ -92,5 +92,3 @@ export function Page() {
     </>
   )
 }
-
-export default Page


### PR DESCRIPTION
## Description

This PR fixes an issue when you create a template and run `yarn build`:
```
Type error: Page "src/app/page.tsx" does not match the required types of a Next.js Page.
```

See [#75](https://github.com/wagmi-dev/create-wagmi/issues/75)

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/create/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
kevinw.eth