### PR TITLE
fix envNamespace in vite-react-rainbowkit template

### DIFF
--- a/templates/vite-react/rainbowkit/_meta.ts
+++ b/templates/vite-react/rainbowkit/_meta.ts
@@ -10,7 +10,7 @@ export default createTemplate({
   description: 'Vite (React) wagmi project with RainbowKit included',
   hooks: compose([
     selectAndInjectProviders({
-      envNamespace: 'process.env',
+      envNamespace: 'import.meta.env',
       envPrefix: 'VITE_',
     }),
     promptAndInjectProjectId({ required: true }),


### PR DESCRIPTION
## Description

This fixes wrong envNamespace variable in the vite-react-rainbotkit template.
'process.env' -> 'import.meta.env'


## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/create/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
goldnite.eth